### PR TITLE
Improve ROS interface to use on-board MAVs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,12 @@ if(MAKE_SCENE)
 	set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMAKE_SCENE=1")
 	find_package(GLEW REQUIRED)
 	include_directories(${GLEW_INCLUDE_DIRS})
-	
+
 	find_package(GLUT REQUIRED)
 	include_directories(${GLUT_INCLUDE_DIRS})
 	link_directories(${GLUT_LIBRARY_DIRS})
 	add_definitions(${GLUT_DEFINITIONS})
-	
+
 	find_package(OpenGL REQUIRED)
 	include_directories(${OpenGL_INCLUDE_DIRS})
 	link_directories(${OpenGL_LIBRARY_DIRS})
@@ -61,7 +61,7 @@ catkin_package(
 	INCLUDE_DIRS include ${catkin_INCLUDE_DIRS}
     LIBRARIES ${PROJECT_NAME}
 	CATKIN_DEPENDS
-	lightweight_filtering 
+	lightweight_filtering
   	kindr
 	roscpp
 	roslib
@@ -78,6 +78,9 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_executable(test_rovio src/test_rovio.cpp)
 target_link_libraries(test_rovio ${catkin_LIBRARIES} ${YamlCpp_LIBRARIES} ${OpenMP_EXE_LINKER_FLAGS} ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${GLEW_LIBRARY})
+
+add_executable(rovio_node src/rovio_node.cpp)
+target_link_libraries(rovio_node ${catkin_LIBRARIES} ${YamlCpp_LIBRARIES} ${OpenMP_EXE_LINKER_FLAGS})
 
 add_executable(feature_tracker_node src/feature_tracker_node.cpp)
 target_link_libraries(feature_tracker_node ${catkin_LIBRARIES} ${YamlCpp_LIBRARIES} ${OpenMP_EXE_LINKER_FLAGS})

--- a/cfg/rovio.info
+++ b/cfg/rovio.info
@@ -1,51 +1,52 @@
 Common
 {
-    doVECalibration true
-    verbose false
-    depthType 1
+	doVECalibration true
+	depthType 1
+	verbose false
 }
 Camera0
 {
-  CalibrationFile init_from_elsewhere.yaml
-  qCM_x  0.0
-  qCM_y  0.0
-  qCM_z  0.0
-  qCM_w  1.0
-  MrMC_x 0
-  MrMC_y 0
-  MrMC_z 0
+	CalibrationFile /home/michael/calibrations/p22035_equidist.yaml ;Sammy11_02_2015_equidist.yaml ;p21012_equidist_190215.yaml; p22035_equidist.yaml
+	qCM_x  0.0
+	qCM_y  0.0
+	qCM_z  0.7071
+	qCM_w  0.7071
+	MrMC_x 0
+	MrMC_y 0
+	MrMC_z 0
 }
 Camera1
 {
-  CalibrationFile init_from_elsewhere.yaml
-  qCM_x  0.0
-  qCM_y  0.0
-  qCM_z  0.0
-  qCM_w  1.0
-  MrMC_x 0
-  MrMC_y 0
-  MrMC_z 0
-}
-Groundtruth
-{
-    doVisualization true
-    qJI_x 0
-    qJI_y 0
-    qJI_z 0
-    qJI_w 1
-    qCB_x 0
-    qCB_y 0
-    qCB_z 0
-    qCB_w 1
-    IrIJ_x 0
-    IrIJ_y 0
-    IrIJ_z 0
-    BrBC_x 0
-    BrBC_y 0
-    BrBC_z 0
+	CalibrationFile /home/michael/calibrations/p22035_equidist_cam1.yaml
+	qCM_x  0.0
+	qCM_y  0.0
+	qCM_z  0.7071
+	qCM_w  0.7071
+	MrMC_x 0
+	MrMC_y 0
+	MrMC_z 0
 }
 Init
 {
+    State
+    {
+        pos_0 0
+        pos_1 0
+        pos_2 0
+        vel_0 0
+        vel_1 0
+        vel_2 0
+        acb_0 0
+        acb_1 0
+        acb_2 0
+        gyb_0 0
+        gyb_1 0
+        gyb_2 0
+        att_x 0
+        att_y 0
+        att_z 0
+        att_w 1
+    }
     Covariance
     {
         pos_0 0.0001
@@ -76,53 +77,25 @@ Init
         vea_4 0.01
         vea_5 0.01
     }
-    State
-    {
-        att_x 0
-        att_y 0
-        att_z 0
-        att_w 1
-        gyb_0 0
-        gyb_1 0
-        gyb_2 0
-        acb_0 0
-        acb_1 0
-        acb_2 0
-        vel_0 0
-        vel_1 0
-        vel_2 0
-        pos_0 0
-        pos_1 0
-        pos_2 0
-    }
 }
 Update0
 {
-    MotionDetection
-    {
-        isEnabled false
-        minFeatureCountForNoMotionDetection 5
-        rateOfMovingFeaturesTh 0.5
-        pixelCoordinateMotionTh 1
-    }
     doPatchWarping true
-    useDirectMethod true
     doFrameVisualisation true
-    removeNegativeFeatureAfterUpdate true
+    useDirectMethod true
     startLevel 3
     endLevel 1
     nDetectionBuckets 100
-    fastDetectionThreshold 10
+    MahalanobisTh 5.8858356 ;5.8858356
     UpdateNoise
     {
         nor 4 ; rad (~1/f ~ 1/400^2 = 1/160000)
     }
-    MahalanobisTh 5.8858356
-    initCovFeature_0 1
+    initCovFeature_0 0.5
     initCovFeature_1 1e-5
     initCovFeature_2 1e-5
-    initDepth 1.0
-    startDetectionTh 0.6
+    initDepth 0.5
+    startDetectionTh 0.8
     scoreDetectionExponent 0.25
     penaltyDistance 100
     zeroDistancePenalty 100
@@ -133,21 +106,30 @@ Update0
     minTrackedAndFreeFeatures 0.5
     minRelativeSTScore 0.75
     minAbsoluteSTScore 5.0
+    fastDetectionThreshold 10
     matchingPixelThreshold 0.0
-    patchRejectionTh 10
-    specialLinearizationThreshold 0.0025
-    maxUncertaintyToDepthRatioForDepthInitialization 0.3
+    specialLinearizationThreshold 0.0025 ; (set to 0 for always, and to large value for never, 1 pixel ~ 0.0025)
+    patchRejectionTh 10.0;
+    removeNegativeFeatureAfterUpdate true;
+    maxUncertaintyToDepthRatioForDepthInitialization 0.3 ; if set to 0.0 the depth is initialized with the standard value provided above, otherwise ROVIO attempts to figure out a median depth in the frame
+    MotionDetection
+    {
+    	isEnabled 1
+	    rateOfMovingFeaturesTh 0.5;
+	    pixelCoordinateMotionTh 1.0;
+	    minFeatureCountForNoMotionDetection 5;
+	}
     ZeroVelocityUpdate
     {
-        isEnabled false
         UpdateNoise
         {
-            vel_0 0.0001
-            vel_1 0.0001
-            vel_2 0.0001
+            vel_0 0.01
+            vel_1 0.01
+            vel_2 0.01
         }
-        minNoMotionTime 1
         MahalanobisTh0 7.689997599999999
+        minNoMotionTime 1.0
+        isEnabled 1 ; only works if MotionDetection.isEnabled is true
     }
 }
 Prediction
@@ -166,12 +148,12 @@ Prediction
         gyb_0 3.8e-7
         gyb_1 3.8e-7
         gyb_2 3.8e-7
-        vep_0 1e-4
-        vep_1 1e-4
-        vep_2 1e-4
-        vep_3 1e-4
-        vep_4 1e-4
-        vep_5 1e-4
+        vep_0 1e-8
+        vep_1 1e-8
+        vep_2 1e-8
+        vep_3 1e-8
+        vep_4 1e-8
+        vep_5 1e-8
         att_0 7.6e-6 ;7.6e-7
         att_1 7.6e-6
         att_2 7.6e-6
@@ -186,7 +168,25 @@ Prediction
     }
     MotionDetection
     {
-        inertialMotionRorTh 0.1
-        inertialMotionAccTh 0.1
-    }
+	    inertialMotionRorTh 0.1
+	    inertialMotionAccTh 0.5
+	}
+}
+Groundtruth
+{
+	doVisualization false
+	IrIJ_x 0.0
+	IrIJ_y 0.0
+	IrIJ_z 0.0
+	qJI_x 0.0
+	qJI_y 0.0
+	qJI_z 0.0
+	qJI_w 1.0
+	BrBC_x 0.0
+	BrBC_y 0.0
+	BrBC_z 0.0
+	qCB_x 0.0
+	qCB_y 0.0
+	qCB_z 0.0
+	qCB_w 1.0
 }

--- a/cfg/rovio.info
+++ b/cfg/rovio.info
@@ -1,52 +1,51 @@
 Common
 {
-	doVECalibration true
-	depthType 1
-	verbose false
+    doVECalibration true
+    verbose false
+    depthType 1
 }
 Camera0
 {
-	CalibrationFile /home/michael/calibrations/p22035_equidist.yaml ;Sammy11_02_2015_equidist.yaml ;p21012_equidist_190215.yaml; p22035_equidist.yaml
-	qCM_x  0.0
-	qCM_y  0.0
-	qCM_z  0.7071
-	qCM_w  0.7071
-	MrMC_x 0
-	MrMC_y 0
-	MrMC_z 0
+  CalibrationFile init_from_elsewhere.yaml
+  qCM_x  0.0
+  qCM_y  0.0
+  qCM_z  0.0
+  qCM_w  1.0
+  MrMC_x 0
+  MrMC_y 0
+  MrMC_z 0
 }
 Camera1
 {
-	CalibrationFile /home/michael/calibrations/p22035_equidist_cam1.yaml
-	qCM_x  0.0
-	qCM_y  0.0
-	qCM_z  0.7071
-	qCM_w  0.7071
-	MrMC_x 0
-	MrMC_y 0
-	MrMC_z 0
+  CalibrationFile init_from_elsewhere.yaml
+  qCM_x  0.0
+  qCM_y  0.0
+  qCM_z  0.0
+  qCM_w  1.0
+  MrMC_x 0
+  MrMC_y 0
+  MrMC_z 0
+}
+Groundtruth
+{
+    doVisualization true
+    qJI_x 0
+    qJI_y 0
+    qJI_z 0
+    qJI_w 1
+    qCB_x 0
+    qCB_y 0
+    qCB_z 0
+    qCB_w 1
+    IrIJ_x 0
+    IrIJ_y 0
+    IrIJ_z 0
+    BrBC_x 0
+    BrBC_y 0
+    BrBC_z 0
 }
 Init
 {
-    State
-    {
-        pos_0 0
-        pos_1 0
-        pos_2 0
-        vel_0 0
-        vel_1 0
-        vel_2 0
-        acb_0 0
-        acb_1 0
-        acb_2 0
-        gyb_0 0
-        gyb_1 0
-        gyb_2 0
-        att_x 0
-        att_y 0
-        att_z 0
-        att_w 1
-    }
     Covariance
     {
         pos_0 0.0001
@@ -77,25 +76,53 @@ Init
         vea_4 0.01
         vea_5 0.01
     }
+    State
+    {
+        att_x 0
+        att_y 0
+        att_z 0
+        att_w 1
+        gyb_0 0
+        gyb_1 0
+        gyb_2 0
+        acb_0 0
+        acb_1 0
+        acb_2 0
+        vel_0 0
+        vel_1 0
+        vel_2 0
+        pos_0 0
+        pos_1 0
+        pos_2 0
+    }
 }
 Update0
 {
+    MotionDetection
+    {
+        isEnabled false
+        minFeatureCountForNoMotionDetection 5
+        rateOfMovingFeaturesTh 0.5
+        pixelCoordinateMotionTh 1
+    }
     doPatchWarping true
-    doFrameVisualisation true
     useDirectMethod true
+    doFrameVisualisation true
+    removeNegativeFeatureAfterUpdate true
     startLevel 3
     endLevel 1
     nDetectionBuckets 100
-    MahalanobisTh 5.8858356 ;5.8858356
+    fastDetectionThreshold 10
     UpdateNoise
     {
         nor 4 ; rad (~1/f ~ 1/400^2 = 1/160000)
     }
-    initCovFeature_0 0.5
+    MahalanobisTh 5.8858356
+    initCovFeature_0 1
     initCovFeature_1 1e-5
     initCovFeature_2 1e-5
-    initDepth 0.5
-    startDetectionTh 0.8
+    initDepth 1.0
+    startDetectionTh 0.6
     scoreDetectionExponent 0.25
     penaltyDistance 100
     zeroDistancePenalty 100
@@ -106,30 +133,21 @@ Update0
     minTrackedAndFreeFeatures 0.5
     minRelativeSTScore 0.75
     minAbsoluteSTScore 5.0
-    fastDetectionThreshold 10
     matchingPixelThreshold 0.0
-    specialLinearizationThreshold 0.0025 ; (set to 0 for always, and to large value for never, 1 pixel ~ 0.0025)
-    patchRejectionTh 10.0;
-    removeNegativeFeatureAfterUpdate true;
-    maxUncertaintyToDepthRatioForDepthInitialization 0.3 ; if set to 0.0 the depth is initialized with the standard value provided above, otherwise ROVIO attempts to figure out a median depth in the frame
-    MotionDetection
-    {
-    	isEnabled 1
-	    rateOfMovingFeaturesTh 0.5;
-	    pixelCoordinateMotionTh 1.0;
-	    minFeatureCountForNoMotionDetection 5;
-	}
+    patchRejectionTh 10
+    specialLinearizationThreshold 0.0025
+    maxUncertaintyToDepthRatioForDepthInitialization 0.3
     ZeroVelocityUpdate
     {
+        isEnabled false
         UpdateNoise
         {
-            vel_0 0.01
-            vel_1 0.01
-            vel_2 0.01
+            vel_0 0.0001
+            vel_1 0.0001
+            vel_2 0.0001
         }
+        minNoMotionTime 1
         MahalanobisTh0 7.689997599999999
-        minNoMotionTime 1.0
-        isEnabled 1 ; only works if MotionDetection.isEnabled is true
     }
 }
 Prediction
@@ -148,12 +166,12 @@ Prediction
         gyb_0 3.8e-7
         gyb_1 3.8e-7
         gyb_2 3.8e-7
-        vep_0 1e-8
-        vep_1 1e-8
-        vep_2 1e-8
-        vep_3 1e-8
-        vep_4 1e-8
-        vep_5 1e-8
+        vep_0 1e-4
+        vep_1 1e-4
+        vep_2 1e-4
+        vep_3 1e-4
+        vep_4 1e-4
+        vep_5 1e-4
         att_0 7.6e-6 ;7.6e-7
         att_1 7.6e-6
         att_2 7.6e-6
@@ -168,25 +186,7 @@ Prediction
     }
     MotionDetection
     {
-	    inertialMotionRorTh 0.1
-	    inertialMotionAccTh 0.5
-	}
-}
-Groundtruth
-{
-	doVisualization false
-	IrIJ_x 0.0
-	IrIJ_y 0.0
-	IrIJ_z 0.0
-	qJI_x 0.0
-	qJI_y 0.0
-	qJI_z 0.0
-	qJI_w 1.0
-	BrBC_x 0.0
-	BrBC_y 0.0
-	BrBC_z 0.0
-	qCB_x 0.0
-	qCB_y 0.0
-	qCB_z 0.0
-	qCB_w 1.0
+        inertialMotionRorTh 0.1
+        inertialMotionAccTh 0.1
+    }
 }

--- a/include/rovio/RovioNode.hpp
+++ b/include/rovio/RovioNode.hpp
@@ -57,6 +57,7 @@ template<typename FILTER>
 class RovioNode{
  public:
   ros::NodeHandle nh_;
+  ros::NodeHandle nh_private_;
   ros::Subscriber subImu_;
   ros::Subscriber subImg0_;
   ros::Subscriber subImg1_;
@@ -107,7 +108,8 @@ class RovioNode{
 
   /** \brief Constructor
    */
-  RovioNode(ros::NodeHandle& nh,FILTER* mpFilter): nh_(nh), mpFilter_(mpFilter){
+  RovioNode(ros::NodeHandle& nh, ros::NodeHandle& nh_private, FILTER* mpFilter)
+      : nh_(nh), nh_private_(nh_private), mpFilter_(mpFilter) {
     #ifndef NDEBUG
       ROS_WARN("====================== Debug Mode ======================");
     #endif
@@ -125,9 +127,9 @@ class RovioNode{
     world_frame_ = "/world";
     camera_frame_ = "/camera";
     imu_frame_ = "/imu";
-    nh_.param("world_frame", world_frame_, world_frame_);
-    nh_.param("camera_frame", camera_frame_, camera_frame_);
-    nh_.param("imu_frame", imu_frame_, imu_frame_);
+    nh_private_.param("world_frame", world_frame_, world_frame_);
+    nh_private_.param("camera_frame", camera_frame_, camera_frame_);
+    nh_private_.param("imu_frame", imu_frame_, imu_frame_);
 
     poseMsg_.header.frame_id = world_frame_;
     rovioOutputMsg_.header.frame_id = world_frame_;

--- a/include/rovio/RovioNode.hpp
+++ b/include/rovio/RovioNode.hpp
@@ -100,28 +100,40 @@ class RovioNode{
   std::queue<rot::RotationQuaternionPD> groundtruth_qCJ_;
   std::queue<Eigen::Vector3d> groundtruth_JrJC_;
 
+  // ROS names for output tf frames.
+  std::string world_frame_;
+  std::string camera_frame_;
+  std::string imu_frame_;
+
   /** \brief Constructor
    */
   RovioNode(ros::NodeHandle& nh,FILTER* mpFilter): nh_(nh), mpFilter_(mpFilter){
     #ifndef NDEBUG
       ROS_WARN("====================== Debug Mode ======================");
     #endif
-    subImu_ = nh_.subscribe("/imu0", 1000, &RovioNode::imuCallback,this);
-    subImg0_ = nh_.subscribe("/cam0/image_raw", 1000, &RovioNode::imgCallback0,this);
-    subImg1_ = nh_.subscribe("/cam1/image_raw", 1000, &RovioNode::imgCallback1,this);
-    subGroundtruth_ = nh_.subscribe("/vicon/auk/auk", 1000, &RovioNode::groundtruthCallback,this);
-    pubPose_ = nh_.advertise<geometry_msgs::PoseStamped>("/rovio/pose", 1);
-    pubTransform_ = nh_.advertise<geometry_msgs::TransformStamped>("/rovio/transform", 1);
-    pubRovioOutput_ = nh_.advertise<RovioOutput>("/rovio/output", 1);
-    pubOdometry_ = nh_.advertise<nav_msgs::Odometry>("/rovio/odometry", 1);
-    pubPcl_ = nh_.advertise<sensor_msgs::PointCloud2>("/rovio/pcl", 1);
-    pubURays_ = nh_.advertise<visualization_msgs::Marker>("/rovio/urays", 1 );
+    subImu_ = nh_.subscribe("imu0", 1000, &RovioNode::imuCallback,this);
+    subImg0_ = nh_.subscribe("cam0/image_raw", 1000, &RovioNode::imgCallback0,this);
+    subImg1_ = nh_.subscribe("cam1/image_raw", 1000, &RovioNode::imgCallback1,this);
+    subGroundtruth_ = nh_.subscribe("vrpn_client/pose", 1000, &RovioNode::groundtruthCallback,this);
+    pubPose_ = nh_.advertise<geometry_msgs::PoseStamped>("rovio/pose", 1);
+    pubTransform_ = nh_.advertise<geometry_msgs::TransformStamped>("rovio/transform", 1);
+    pubRovioOutput_ = nh_.advertise<RovioOutput>("rovio/output", 1);
+    pubOdometry_ = nh_.advertise<nav_msgs::Odometry>("rovio/odometry", 1);
+    pubPcl_ = nh_.advertise<sensor_msgs::PointCloud2>("rovio/pcl", 1);
+    pubURays_ = nh_.advertise<visualization_msgs::Marker>("rovio/urays", 1 );
 
-    poseMsg_.header.frame_id = "/world";
-    rovioOutputMsg_.header.frame_id = "/world";
-    rovioOutputMsg_.points.header.frame_id = "/camera";
-    odometryMsg_.header.frame_id = "/world";
-    odometryMsg_.child_frame_id = "/camera";
+    world_frame_ = "/world";
+    camera_frame_ = "/camera";
+    imu_frame_ = "/imu";
+    nh_.param("world_frame", world_frame_, world_frame_);
+    nh_.param("camera_frame", camera_frame_, camera_frame_);
+    nh_.param("imu_frame", imu_frame_, imu_frame_);
+
+    poseMsg_.header.frame_id = world_frame_;
+    rovioOutputMsg_.header.frame_id = world_frame_;
+    rovioOutputMsg_.points.header.frame_id = camera_frame_;
+    odometryMsg_.header.frame_id = world_frame_;
+    odometryMsg_.child_frame_id = camera_frame_;
     poseMsgSeq_ = 1;
     isInitialized_ = false;
   }
@@ -331,8 +343,8 @@ class RovioNode{
 
         // Send camera pose.
         tf::StampedTransform tf_transform_v;
-        tf_transform_v.frame_id_ = "world";
-        tf_transform_v.child_frame_id_ = "camera";
+        tf_transform_v.frame_id_ = world_frame_;
+        tf_transform_v.child_frame_id_ = camera_frame_;
         tf_transform_v.stamp_ = ros::Time(mpFilter_->safe_.t_);
         tf_transform_v.setOrigin(tf::Vector3(WrWC(0),WrWC(1),WrWC(2)));
         tf_transform_v.setRotation(tf::Quaternion(qCW.x(),qCW.y(),qCW.z(),qCW.w()));
@@ -340,8 +352,8 @@ class RovioNode{
 
         // Send IMU pose.
         tf::StampedTransform tf_transform;
-        tf_transform.frame_id_ = "world";
-        tf_transform.child_frame_id_ = "imu";
+        tf_transform.frame_id_ = world_frame_;
+        tf_transform.child_frame_id_ = imu_frame_;
         tf_transform.stamp_ = ros::Time(mpFilter_->safe_.t_);
         Eigen::Vector3d WrWM = state.WrWM();
         rot::RotationQuaternionPD qMW = state.qWM().inverted();
@@ -468,7 +480,7 @@ class RovioNode{
         sensor_msgs::PointCloud2 pcl_msg;
         pcl_msg.header.seq = poseMsgSeq_;
         pcl_msg.header.stamp = ros::Time(mpFilter_->safe_.t_);
-        pcl_msg.header.frame_id = "camera";
+        pcl_msg.header.frame_id = camera_frame_;
         pcl_msg.height = 1;               // Unordered point cloud.
         pcl_msg.width  = mtState::nMax_;  // Number of features/points.
         pcl_msg.fields.resize(4);
@@ -504,7 +516,7 @@ class RovioNode{
 
         // Marker message (Uncertainty rays).
         visualization_msgs::Marker marker_msg;
-        marker_msg.header.frame_id = "camera";
+        marker_msg.header.frame_id = camera_frame_;
         marker_msg.header.stamp = ros::Time(mpFilter_->safe_.t_);
         marker_msg.id = 0;
         marker_msg.type = visualization_msgs::Marker::LINE_LIST;

--- a/include/rovio/rovioFilter.hpp
+++ b/include/rovio/rovioFilter.hpp
@@ -74,7 +74,6 @@ class RovioFilter:public LWF::FilterBase<ImuPrediction<FILTERSTATE>,ImgUpdate<FI
     boolRegister_.registerScalar("Common.doVECalibration",init_.state_.aux().doVECalibration_);
     intRegister_.registerScalar("Common.depthType",init_.state_.aux().depthTypeInt_);
     for(int camID=0;camID<FILTERSTATE::mtState::nCam_;camID++){
-      cameraCalibrationFile_[camID] = "calib.yaml";
       stringRegister_.registerScalar("Camera" + std::to_string(camID) + ".CalibrationFile",cameraCalibrationFile_[camID]);
       doubleRegister_.registerVector("Camera" + std::to_string(camID) + ".MrMC",init_.state_.aux().MrMC_[camID]);
       doubleRegister_.registerQuaternion("Camera" + std::to_string(camID) + ".qCM",init_.state_.aux().qCM_[camID]);
@@ -122,7 +121,9 @@ class RovioFilter:public LWF::FilterBase<ImuPrediction<FILTERSTATE>,ImgUpdate<FI
    */
   void refreshProperties(){
     for(int camID = 0;camID<mtState::nCam_;camID++){
-      cameras_[camID].load(cameraCalibrationFile_[camID]); // TODO IMG
+      if (!cameraCalibrationFile_[camID].empty()) {
+        cameras_[camID].load(cameraCalibrationFile_[camID]); // TODO IMG
+      }
     }
     init_.state_.aux().depthMap_.setType(init_.state_.aux().depthTypeInt_);
   };

--- a/include/rovio/rovioFilter.hpp
+++ b/include/rovio/rovioFilter.hpp
@@ -74,7 +74,6 @@ class RovioFilter:public LWF::FilterBase<ImuPrediction<FILTERSTATE>,ImgUpdate<FI
     boolRegister_.registerScalar("Common.doVECalibration",init_.state_.aux().doVECalibration_);
     intRegister_.registerScalar("Common.depthType",init_.state_.aux().depthTypeInt_);
     for(int camID=0;camID<FILTERSTATE::mtState::nCam_;camID++){
-      cameraCalibrationFile_[camID] = "calib.yaml";
       stringRegister_.registerScalar("Camera" + std::to_string(camID) + ".CalibrationFile",cameraCalibrationFile_[camID]);
       doubleRegister_.registerVector("Camera" + std::to_string(camID) + ".MrMC",init_.state_.aux().MrMC_[camID]);
       doubleRegister_.registerQuaternion("Camera" + std::to_string(camID) + ".qCM",init_.state_.aux().qCM_[camID]);

--- a/include/rovio/rovioFilter.hpp
+++ b/include/rovio/rovioFilter.hpp
@@ -74,6 +74,7 @@ class RovioFilter:public LWF::FilterBase<ImuPrediction<FILTERSTATE>,ImgUpdate<FI
     boolRegister_.registerScalar("Common.doVECalibration",init_.state_.aux().doVECalibration_);
     intRegister_.registerScalar("Common.depthType",init_.state_.aux().depthTypeInt_);
     for(int camID=0;camID<FILTERSTATE::mtState::nCam_;camID++){
+      cameraCalibrationFile_[camID] = "calib.yaml";
       stringRegister_.registerScalar("Camera" + std::to_string(camID) + ".CalibrationFile",cameraCalibrationFile_[camID]);
       doubleRegister_.registerVector("Camera" + std::to_string(camID) + ".MrMC",init_.state_.aux().MrMC_[camID]);
       doubleRegister_.registerQuaternion("Camera" + std::to_string(camID) + ".qCM",init_.state_.aux().qCM_[camID]);

--- a/include/rovio/rovioFilter.hpp
+++ b/include/rovio/rovioFilter.hpp
@@ -74,6 +74,7 @@ class RovioFilter:public LWF::FilterBase<ImuPrediction<FILTERSTATE>,ImgUpdate<FI
     boolRegister_.registerScalar("Common.doVECalibration",init_.state_.aux().doVECalibration_);
     intRegister_.registerScalar("Common.depthType",init_.state_.aux().depthTypeInt_);
     for(int camID=0;camID<FILTERSTATE::mtState::nCam_;camID++){
+      cameraCalibrationFile_[camID] = "";
       stringRegister_.registerScalar("Camera" + std::to_string(camID) + ".CalibrationFile",cameraCalibrationFile_[camID]);
       doubleRegister_.registerVector("Camera" + std::to_string(camID) + ".MrMC",init_.state_.aux().MrMC_[camID]);
       doubleRegister_.registerQuaternion("Camera" + std::to_string(camID) + ".qCM",init_.state_.aux().qCM_[camID]);

--- a/src/rovio_node.cpp
+++ b/src/rovio_node.cpp
@@ -50,6 +50,9 @@ int main(int argc, char** argv){
 
   // Filter
   mtFilter* mpFilter = new mtFilter;
+
+  mpFilter->readFromInfo(filter_config);
+
   // Force the camera calibration paths to the ones from ROS parameters.
   for (unsigned int camID = 0; camID < nCam_; ++camID) {
     std::string camera_config;
@@ -58,7 +61,7 @@ int main(int argc, char** argv){
       mpFilter->cameraCalibrationFile_[camID] = camera_config;
     }
   }
-  mpFilter->readFromInfo(filter_config);
+  mpFilter->refreshProperties();
 
   // Node
   rovio::RovioNode<mtFilter> rovioNode(nh, mpFilter);

--- a/src/rovio_node.cpp
+++ b/src/rovio_node.cpp
@@ -50,8 +50,6 @@ int main(int argc, char** argv){
 
   // Filter
   mtFilter* mpFilter = new mtFilter;
-  mpFilter->readFromInfo(filter_config);
-
   // Force the camera calibration paths to the ones from ROS parameters.
   for (unsigned int camID = 0; camID < nCam_; ++camID) {
     std::string camera_config;
@@ -60,12 +58,10 @@ int main(int argc, char** argv){
       mpFilter->cameraCalibrationFile_[camID] = camera_config;
     }
   }
+  mpFilter->readFromInfo(filter_config);
 
   // Node
   rovio::RovioNode<mtFilter> rovioNode(nh, mpFilter);
-
-
-  //rovioNode.refreshProperties();
   rovioNode.makeTest();
 
   ros::spin();

--- a/src/rovio_node.cpp
+++ b/src/rovio_node.cpp
@@ -64,7 +64,7 @@ int main(int argc, char** argv){
   mpFilter->refreshProperties();
 
   // Node
-  rovio::RovioNode<mtFilter> rovioNode(nh, mpFilter);
+  rovio::RovioNode<mtFilter> rovioNode(nh, nh_private, mpFilter);
   rovioNode.makeTest();
 
   ros::spin();

--- a/src/rovio_node.cpp
+++ b/src/rovio_node.cpp
@@ -35,7 +35,7 @@
 static constexpr unsigned int nMax_ = 25;    // Maximal number of considered features in the filter state.
 static constexpr int nLevels_ = 4;           // Total number of pyramid levels considered.
 static constexpr int patchSize_ = 8;         // Edge length of the patches (in pixel). Must be a multiple of 2!
-static constexpr int nCam_ = 2;              // Used total number of cameras.
+static constexpr int nCam_ = 1;              // Used total number of cameras.
 typedef rovio::RovioFilter<rovio::FilterState<nMax_,nLevels_,patchSize_,nCam_>> mtFilter;
 
 int main(int argc, char** argv){

--- a/src/rovio_node.cpp
+++ b/src/rovio_node.cpp
@@ -30,50 +30,45 @@
 
 #include "rovio/rovioFilter.hpp"
 #include "rovio/RovioNode.hpp"
-#ifdef MAKE_SCENE
-#include "rovio/RovioScene.hpp"
-#endif
 
+// TODO(helenol): expose these as ROS params as well?
 static constexpr unsigned int nMax_ = 25;    // Maximal number of considered features in the filter state.
 static constexpr int nLevels_ = 4;           // Total number of pyramid levels considered.
 static constexpr int patchSize_ = 8;         // Edge length of the patches (in pixel). Must be a multiple of 2!
 static constexpr int nCam_ = 2;              // Used total number of cameras.
 typedef rovio::RovioFilter<rovio::FilterState<nMax_,nLevels_,patchSize_,nCam_>> mtFilter;
 
-#ifdef MAKE_SCENE
-rovio::RovioScene<mtFilter> mRovioScene;
-
-void idleFunc(){
-  ros::spinOnce();
-  mRovioScene.drawScene(mRovioScene.mpFilter_->safe_);
-}
-#endif
-
 int main(int argc, char** argv){
-  ros::init(argc, argv, "TestFilter");
+  ros::init(argc, argv, "rovio");
   ros::NodeHandle nh;
-  std::string rootdir = ros::package::getPath("rovio");
+  ros::NodeHandle nh_private("~");
+
+  std::string filter_config = ros::package::getPath("rovio") +
+      "/cfg/rovio.info";
+
+  nh_private.param("filter_config", filter_config, filter_config);
 
   // Filter
   mtFilter* mpFilter = new mtFilter;
-  mpFilter->readFromInfo(rootdir + "/cfg/rovio.info");
+  mpFilter->readFromInfo(filter_config);
+
+  // Force the camera calibration paths to the ones from ROS parameters.
+  for (unsigned int camID = 0; camID < nCam_; ++camID) {
+    std::string camera_config;
+    if (nh_private.getParam("camera" + std::to_string(camID)
+                            + "_config", camera_config)) {
+      mpFilter->cameraCalibrationFile_[camID] = camera_config;
+    }
+  }
 
   // Node
-  rovio::RovioNode<mtFilter> rovioNode(nh,mpFilter);
+  rovio::RovioNode<mtFilter> rovioNode(nh, mpFilter);
+
+
+  //rovioNode.refreshProperties();
   rovioNode.makeTest();
 
-
-#ifdef MAKE_SCENE
-  // Scene
-  std::string mVSFileName = rootdir + "/shaders/shader.vs";
-  std::string mFSFileName = rootdir + "/shaders/shader.fs";
-  mRovioScene.initScene(argc,argv,mVSFileName,mFSFileName,mpFilter);
-  mRovioScene.setIdleFunction(idleFunc);
-  mRovioScene.addKeyboardCB('r',[&rovioNode]() mutable {rovioNode.isInitialized_=false;});
-  glutMainLoop();
-#else
   ros::spin();
-#endif
 
   delete mpFilter;
   return 0;

--- a/src/test_rovio.cpp
+++ b/src/test_rovio.cpp
@@ -37,7 +37,7 @@
 static constexpr unsigned int nMax_ = 25;    // Maximal number of considered features in the filter state.
 static constexpr int nLevels_ = 4;           // Total number of pyramid levels considered.
 static constexpr int patchSize_ = 8;         // Edge length of the patches (in pixel). Must be a multiple of 2!
-static constexpr int nCam_ = 2;              // Used total number of cameras.
+static constexpr int nCam_ = 1;              // Used total number of cameras.
 typedef rovio::RovioFilter<rovio::FilterState<nMax_,nLevels_,patchSize_,nCam_>> mtFilter;
 
 #ifdef MAKE_SCENE

--- a/src/test_rovio.cpp
+++ b/src/test_rovio.cpp
@@ -52,6 +52,7 @@ void idleFunc(){
 int main(int argc, char** argv){
   ros::init(argc, argv, "TestFilter");
   ros::NodeHandle nh;
+  ros::NodeHandle nh_private("~");
   std::string rootdir = ros::package::getPath("rovio");
 
   // Filter
@@ -59,7 +60,7 @@ int main(int argc, char** argv){
   mpFilter->readFromInfo(rootdir + "/cfg/rovio.info");
 
   // Node
-  rovio::RovioNode<mtFilter> rovioNode(nh,mpFilter);
+  rovio::RovioNode<mtFilter> rovioNode(nh, nh_private, mpFilter);
   rovioNode.makeTest();
 
 


### PR DESCRIPTION
Tried to keep default behavior largely the same, but make it a little bit more configurable. :)
  - Moved all topics to non-global namespace (multiple MAVs at once!)
  - Changed ground truth topic to vrpn_cline/pose, since this is the new convention (let me know if you want me to change this one back so the old bag files work). This is the only change that affects default behavior.
  - Exposed TF frame names as ROS parameters for world, camera, and IMU.
  - Added a new frontend other than test_rovio, takes filter parameters as ROS param.
  - Takes camera config paths as param as well; this means default is no longer "config.yaml". Just set CalibrationFile to blank to use the ROS paths.

The actual config files used for testing are in https://github.com/ethz-asl/mav_tools/pull/43 if you have any feedback on those, too.