### PR TITLE
added std namespace to isnan

### DIFF
--- a/include/rovio/MultilevelPatchAlignment.hpp
+++ b/include/rovio/MultilevelPatchAlignment.hpp
@@ -411,7 +411,7 @@ class MultilevelPatchAlignment {
     cOut = cInit;
     Eigen::Vector3f update; update.setZero();
     for(int iter = 0; iter<maxIter; ++iter){
-      if(isnan(cOut.get_c().x) || isnan(cOut.get_c().y)){
+      if(std::isnan(cOut.get_c().x) || std::isnan(cOut.get_c().y)){
         assert(false);
         return false;
       }
@@ -522,7 +522,7 @@ class MultilevelPatchAlignment {
     update.setZero();
     bool converged = false;
     for(int iter = 0; iter<maxIter; ++iter){
-      if(isnan(cOut.get_c().x) || isnan(cOut.get_c().y)){
+      if(std::isnan(cOut.get_c().x) || std::isnan(cOut.get_c().y)){
         assert(false);
         return false;
       }


### PR DESCRIPTION
Same issue as in mono_dense_reconstruction. gcc v5.3.1 throws error if std namespace is omitted.