### PR TITLE
adapted to new kindr1, improved parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ http://projects.asl.ethz.ch/datasets/doku.php?id=kmavvisualinertialdatasets
 
 ### Further notes ###
 * Camera matrix and distortion parameters should be provided by a yaml file or loaded through rosparam
-* The cfg/rovio.info provides most parameters for rovio. The camera extrinsics qCM (quaternion from IMU to camera frame, JPL-convention) and MrMC (Translation between IMU and Camera expressed in the IMU frame) should also be set there. They are being estimated during runtime so only a rough guess should be sufficient.
+* The cfg/rovio.info provides most parameters for rovio. The camera extrinsics qCM (quaternion from IMU to camera frame, Hamilton-convention) and MrMC (Translation between IMU and Camera expressed in the IMU frame) should also be set there. They are being estimated during runtime so only a rough guess should be sufficient.
 * Especially for application with little motion fixing the IMU-camera extrinsics can be beneficial. This can be done by setting the parameter doVECalibration to false. Please be carefull that the overall robustness and accuracy can be very sensitive to bad extrinsic calibrations.

--- a/cfg/rovio.info
+++ b/cfg/rovio.info
@@ -9,10 +9,10 @@ Common
 Camera0
 {
 	CalibrationFile ;												Camera-Calibration file for intrinsics
-	qCM_x  -0.00666398307551;										X-entry of IMU to Camera quaterion (JPL)
-	qCM_y  0.0079168224269;										Y-entry of IMU to Camera quaterion (JPL)
-	qCM_z  0.701985972528;											Z-entry of IMU to Camera quaterion (JPL)
-	qCM_w   0.712115587266;											W-entry of IMU to Camera quaterion (JPL)
+	qCM_x  0.00666398307551;										X-entry of IMU to Camera quaterion (Hamilton)
+	qCM_y  -0.0079168224269;										Y-entry of IMU to Camera quaterion (Hamilton)
+	qCM_z  -0.701985972528;											Z-entry of IMU to Camera quaterion (Hamilton)
+	qCM_w   0.712115587266;											W-entry of IMU to Camera quaterion (Hamilton)
 	MrMC_x -0.0111674199187;											X-entry of IMU to Camera vector (expressed in IMU CF) [m]
 	MrMC_y -0.0574640920022;										Y-entry of IMU to Camera vector (expressed in IMU CF) [m]
 	MrMC_z 0.0207586947896;											Z-entry of IMU to Camera vector (expressed in IMU CF) [m]
@@ -20,10 +20,10 @@ Camera0
 Camera1
 {
 	CalibrationFile ;												Camera-Calibration file for intrinsics
-	qCM_x  -0.00151329637706;										X-entry of IMU to Camera quaterion (JPL)
-	qCM_y  0.0123329249764;										Y-entry of IMU to Camera quaterion (JPL)
-	qCM_z  0.702657352863;											Z-entry of IMU to Camera quaterion (JPL)
-	qCM_w  0.711419885414;											W-entry of IMU to Camera quaterion (JPL)
+	qCM_x  0.00151329637706;										X-entry of IMU to Camera quaterion (Hamilton)
+	qCM_y  -0.0123329249764;										Y-entry of IMU to Camera quaterion (Hamilton)
+	qCM_z  -0.702657352863;											Z-entry of IMU to Camera quaterion (Hamilton)
+	qCM_w  0.711419885414;											W-entry of IMU to Camera quaterion (Hamilton)
 	MrMC_x -0.0091929160801;											X-entry of IMU to Camera vector (expressed in IMU CF) [m]
 	MrMC_y 0.0540646643676;										Y-entry of IMU to Camera vector (expressed in IMU CF) [m]
 	MrMC_z 0.0190387660614;											Z-entry of IMU to Camera vector (expressed in IMU CF) [m]
@@ -44,10 +44,10 @@ Init
         gyb_0 0;			X-entry of gyroscope bias [rad/s]
         gyb_1 0;			Y-entry of gyroscope bias [rad/s]
         gyb_2 0;			Z-entry of gyroscope bias [rad/s]
-        att_x 0;			X-entry of initial attitude (IMU to world, JPL)
-        att_y 0;			Y-entry of initial attitude (IMU to world, JPL)
-        att_z 0;			Z-entry of initial attitude (IMU to world, JPL)
-        att_w 1;			W-entry of initial attitude (IMU to world, JPL)
+        att_x 0;			X-entry of initial attitude (IMU to world, Hamilton)
+        att_y 0;			Y-entry of initial attitude (IMU to world, Hamilton)
+        att_z 0;			Z-entry of initial attitude (IMU to world, Hamilton)
+        att_w 1;			W-entry of initial attitude (IMU to world, Hamilton)
     }
     Covariance
     {
@@ -87,13 +87,13 @@ ImgUpdate
         pix 2;													Covariance used for the reprojection error, 1/focal_length is roughly 1 pixel std [rad] (~1/f ~ 1/400^2 = 1/160000)
         int 400;												Covariance used for the photometric error [intensity^2]
     }
-    initCovFeature_0 4.0;										Covariance for the initial distance (Relative to initialization depth [m^2/m^2])
+    initCovFeature_0 0.5;										Covariance for the initial distance (Relative to initialization depth [m^2/m^2])
     initCovFeature_1 1e-5;										Covariance for the initial bearing vector, x-component [rad^2]
     initCovFeature_2 1e-5;										Covariance for the initial bearing vector, y-component [rad^2]
     initDepth 0.5;												Initial value for the initial distance parameter
     startDetectionTh 0.8;										Threshold for detecting new features (min: 0, max: 1)
     scoreDetectionExponent 0.25;								Exponent used for weighting the distance between candidates
-    penaltyDistance 50;										Maximal distance which gets penalized during bucketing [pix]
+    penaltyDistance 100;										Maximal distance which gets penalized during bucketing [pix]
     zeroDistancePenalty 100;									Penalty for zero distance (max: nDetectionBuckets)
     statLocalQualityRange 10;									Number of frames for local quality evaluation
     statLocalVisibilityRange 100;								Number of frames for local visibility evaluation
@@ -198,17 +198,17 @@ PoseUpdate
 	noFeedbackToRovio true;						By default the pose update is only used for aligning coordinate frame. Set to false if ROVIO should benefit frome the posed measurements.
 	doInertialAlignmentAtStart true;			Should the transformation between I and W be explicitly computed and set with the first pose measurement.
 	timeOffset 0.0;								Time offset added to the pose measurement timestamps
-    qVM_x 0;									X-entry of quaterion representing IMU to reference body coordinate frame of pose measurement (JPL)
-    qVM_y 0;									Y-entry of quaterion representing IMU to reference body coordinate frame of pose measurement (JPL)
-    qVM_z 0;									Z-entry of quaterion representing IMU to reference body coordinate frame of pose measurement (JPL)
-    qVM_w 1;									W-entry of quaterion representing IMU to reference body coordinate frame of pose measurement (JPL)
+    qVM_x 0;									X-entry of quaterion representing IMU to reference body coordinate frame of pose measurement (Hamilton)
+    qVM_y 0;									Y-entry of quaterion representing IMU to reference body coordinate frame of pose measurement (Hamilton)
+    qVM_z 0;									Z-entry of quaterion representing IMU to reference body coordinate frame of pose measurement (Hamilton)
+    qVM_w 1;									W-entry of quaterion representing IMU to reference body coordinate frame of pose measurement (Hamilton)
     MrMV_x 0;									X-entry of vector representing IMU to reference body coordinate frame of pose measurement
     MrMV_y 0;									Y-entry of vector representing IMU to reference body coordinate frame of pose measurement
     MrMV_z 0;									Z-entry of vector representing IMU to reference body coordinate frame of pose measurement
-    qWI_x 0;									X-entry of quaterion representing World to reference inertial coordinate frame of pose measurement (JPL)
-    qWI_y 0;									Y-entry of quaterion representing World to reference inertial coordinate frame of pose measurement (JPL)
-    qWI_z 0;									Z-entry of quaterion representing World to reference inertial coordinate frame of pose measurement (JPL)
-    qWI_w 1;									W-entry of quaterion representing World to reference inertial coordinate frame of pose measurement (JPL)
+    qWI_x 0;									X-entry of quaterion representing World to reference inertial coordinate frame of pose measurement (Hamilton)
+    qWI_y 0;									Y-entry of quaterion representing World to reference inertial coordinate frame of pose measurement (Hamilton)
+    qWI_z 0;									Z-entry of quaterion representing World to reference inertial coordinate frame of pose measurement (Hamilton)
+    qWI_w 1;									W-entry of quaterion representing World to reference inertial coordinate frame of pose measurement (Hamilton)
     IrIW_x 0;									X-entry of vector representing World to reference inertial coordinate frame of pose measurement
     IrIW_y 0;									Y-entry of vector representing World to reference inertial coordinate frame of pose measurement
     IrIW_z 0;									Z-entry of vector representing World to reference inertial coordinate frame of pose measurement

--- a/include/rovio/CoordinateTransform/LandmarkOutput.hpp
+++ b/include/rovio/CoordinateTransform/LandmarkOutput.hpp
@@ -93,7 +93,7 @@ class LandmarkOutputImuCT:public LWF::CoordinateTransform<STATE,LandmarkOutput>{
 
     if(input.aux().doVECalibration_){
       J.template block<3,3>(mtOutput::template getId<mtOutput::_lmk>(),mtInput::template getId<mtInput::_vep>()) = M3D::Identity();
-      J.template block<3,3>(mtOutput::template getId<mtOutput::_lmk>(),mtInput::template getId<mtInput::_vea>()) = -mBC*gSM(CrCP);
+      J.template block<3,3>(mtOutput::template getId<mtOutput::_lmk>(),mtInput::template getId<mtInput::_vea>()) = mBC*gSM(CrCP);
     }
   }
 };

--- a/include/rovio/CoordinateTransform/RovioOutput.hpp
+++ b/include/rovio/CoordinateTransform/RovioOutput.hpp
@@ -122,7 +122,7 @@ class CameraOutputCT:public LWF::CoordinateTransform<STATE,StandardOutput>{
     J.setZero();
     J.template block<3,3>(mtOutput::template getId<mtOutput::_pos>(),mtInput::template getId<mtInput::_pos>()) = M3D::Identity();
     J.template block<3,3>(mtOutput::template getId<mtOutput::_pos>(),mtInput::template getId<mtInput::_att>()) =
-        gSM(input.qWM().rotate(input.MrMC(camID_)));
+        -gSM(input.qWM().rotate(input.MrMC(camID_)));
     J.template block<3,3>(mtOutput::template getId<mtOutput::_att>(),mtInput::template getId<mtInput::_att>()) =
         -MPD(input.qCM(camID_)*input.qWM().inverted()).matrix();
     J.template block<3,3>(mtOutput::template getId<mtOutput::_vel>(),mtInput::template getId<mtInput::_vel>()) = -MPD(input.qCM(camID_)).matrix();
@@ -135,9 +135,9 @@ class CameraOutputCT:public LWF::CoordinateTransform<STATE,StandardOutput>{
       J.template block<3,3>(mtOutput::template getId<mtOutput::_vel>(),mtInput::template getId<mtInput::_vep>(camID_)) =
           MPD(input.qCM(camID_)).matrix()*gSM(V3D(input.aux().MwWMmeas_-input.gyb()));
       J.template block<3,3>(mtOutput::template getId<mtOutput::_ror>(),mtInput::template getId<mtInput::_vea>(camID_)) =
-          gSM(input.qCM(camID_).rotate(V3D(input.aux().MwWMmeas_-input.gyb())));
+          -gSM(input.qCM(camID_).rotate(V3D(input.aux().MwWMmeas_-input.gyb())));
       J.template block<3,3>(mtOutput::template getId<mtOutput::_vel>(),mtInput::template getId<mtInput::_vea>(camID_)) =
-          gSM(input.qCM(camID_).rotate(V3D(-input.MvM() + gSM(V3D(input.aux().MwWMmeas_-input.gyb()))*input.MrMC())));
+          -gSM(input.qCM(camID_).rotate(V3D(-input.MvM() + gSM(V3D(input.aux().MwWMmeas_-input.gyb()))*input.MrMC())));
       J.template block<3,3>(mtOutput::template getId<mtOutput::_att>(),mtInput::template getId<mtInput::_vea>(camID_)) =
           M3D::Identity();
     }

--- a/include/rovio/CoordinateTransform/YprOutput.hpp
+++ b/include/rovio/CoordinateTransform/YprOutput.hpp
@@ -60,29 +60,11 @@ class AttitudeToYprCT:public LWF::CoordinateTransform<AttitudeOutput,YprOutput>{
   AttitudeToYprCT(){};
   virtual ~AttitudeToYprCT(){};
   void evalTransform(mtOutput& output, const mtInput& input) const{
-    output.template get<mtOutput::_ypr>() = rot::EulerAnglesYprPD(input.template get<mtInput::_att>()).vector();
+    output.template get<mtOutput::_ypr>() = kindr::EulerAnglesZyxD(input.template get<mtInput::_att>()).vector();
   }
   void jacTransform(MXD& J, const mtInput& input) const{
-    J.setZero();
-
-    rot::EulerAnglesYprPD ypr(input.template get<mtInput::_att>());
-    const double theta = ypr.pitch();
-    const double phi = ypr.roll();
-    const double t2 = cos(theta);
-    const double t3 = 1.0/t2;
-    const double t4 = cos(phi);
-    const double t5 = sin(phi);
-    const double t6 = sin(theta);
-
-    J(0,0) = 0.0;
-    J(0,1) = t3*t5;
-    J(0,2) = t3*t4;
-    J(1,0) = 0.0;
-    J(1,1) = t4;
-    J(1,2) = -t5;
-    J(2,0) = 1.0;
-    J(2,1) = t3*t5*t6;
-    J(2,2) = t3*t4*t6;
+    kindr::EulerAnglesZyxD zyx(input.template get<mtInput::_att>());
+    J = zyx.getMappingFromLocalAngularVelocityToDiff()*MPD(input.template get<mtInput::_att>().inverted()).matrix();
   }
 };
 

--- a/include/rovio/FilterStates.hpp
+++ b/include/rovio/FilterStates.hpp
@@ -92,7 +92,7 @@ class StateAuxiliary: public LWF::AuxiliaryBase<StateAuxiliary<nMax,nLevels,patc
   int activeCameraCounter_;  /**<Counter for iterating through the cameras, used such that when updating a feature we always start with the camId where the feature is expressed in.*/
   double timeSinceLastInertialMotion_;  /**<Time since the IMU showed motion last.*/
   double timeSinceLastImageMotion_;  /**<Time since the Image showed motion last.*/
-  rot::RotationQuaternionPD poseMeasRot_; /**<Groundtruth attitude measurement. qMI.*/
+  QPD poseMeasRot_; /**<Groundtruth attitude measurement. qMI.*/
   Eigen::Vector3d poseMeasLin_; /**<Groundtruth position measurement. IrIM*/
   FeatureManager<nLevels,patchSize,nCam>* mpCurrentFeature_; /**<Pointer to active feature*/
 };
@@ -591,7 +591,7 @@ class FilterState: public LWF::FilterState<State<nMax,nLevels,patchSize,nCam,nPo
   void initWithAccelerometer(const V3D& fMeasInit){
     V3D unitZ(0,0,1);
     if(fMeasInit.norm()>1e-6){
-      state_.qWM().setFromVectors(unitZ,fMeasInit);
+      state_.qWM().setFromVectors(fMeasInit,unitZ);
     } else {
       state_.qWM().setIdentity();
     }

--- a/include/rovio/PoseUpdate.hpp
+++ b/include/rovio/PoseUpdate.hpp
@@ -224,13 +224,13 @@ class PoseUpdate: public LWF::Update<PoseInnovation,FILTERSTATE,PoseUpdateMeas,P
         F.template block<3,3>(mtInnovation::template getId<mtInnovation::_pos>(),mtState::template getId<mtState::_pos>()) =
             MPD(get_qWI(state).inverted()).matrix();
         F.template block<3,3>(mtInnovation::template getId<mtInnovation::_pos>(),mtState::template getId<mtState::_att>()) =
-            MPD(get_qWI(state).inverted()).matrix()*gSM(state.qWM().rotate(get_MrMV(state)));
+            -MPD(get_qWI(state).inverted()).matrix()*gSM(state.qWM().rotate(get_MrMV(state)));
       }
       if(inertialPoseIndex_ >= 0){
         F.template block<3,3>(mtInnovation::template getId<mtInnovation::_pos>(),mtState::template getId<mtState::_pop>(inertialPoseIndex_)) =
             M3D::Identity();
         F.template block<3,3>(mtInnovation::template getId<mtInnovation::_pos>(),mtState::template getId<mtState::_poa>(inertialPoseIndex_)) =
-            -gSM(get_qWI(state).inverseRotate(V3D(state.WrWM()+state.qWM().rotate(get_MrMV(state)))))*MPD(get_qWI(state).inverted()).matrix();
+            gSM(get_qWI(state).inverseRotate(V3D(state.WrWM()+state.qWM().rotate(get_MrMV(state)))))*MPD(get_qWI(state).inverted()).matrix();
       }
       if(bodyPoseIndex_ >= 0){
         F.template block<3,3>(mtInnovation::template getId<mtInnovation::_pos>(),mtState::template getId<mtState::_pop>(bodyPoseIndex_)) =

--- a/include/rovio/RovioFilter.hpp
+++ b/include/rovio/RovioFilter.hpp
@@ -37,8 +37,6 @@
 #include "rovio/ImuPrediction.hpp"
 #include "rovio/MultiCamera.hpp"
 
-namespace rot = kindr::rotations::eigen_impl;
-
 namespace rovio {
 /** \brief Class, defining the Rovio Filter.
  *
@@ -219,8 +217,8 @@ class RovioFilter:public LWF::FilterBase<ImuPrediction<FILTERSTATE>,ImgUpdate<FI
    *  @param camID -  ID of the considered camera.
    */
   void setExtrinsics(const Eigen::Matrix3d& R_CM, const Eigen::Vector3d& CrCM, const int camID = 0){
-    rot::RotationMatrixAD R(R_CM);
-    init_.state_.aux().qCM_[camID] = QPD(R.getPassive());
+    kindr::RotationMatrixD R(R_CM);
+    init_.state_.aux().qCM_[camID] = QPD(R);
     init_.state_.aux().MrMC_[camID] = -init_.state_.aux().qCM_[camID].inverseRotate(CrCM);
   }
 };

--- a/include/rovio/RovioNode.hpp
+++ b/include/rovio/RovioNode.hpp
@@ -576,11 +576,14 @@ class RovioNode{
     if(init_state_.isInitialized()){
       // Execute the filter update.
       const double t1 = (double) cv::getTickCount();
-      int c1 = std::get<0>(mpFilter_->updateTimelineTuple_).measMap_.size();
       static double timing_T = 0;
       static int timing_C = 0;
       const double oldSafeTime = mpFilter_->safe_.t_;
-      mpFilter_->updateSafe();
+      int c1 = std::get<0>(mpFilter_->updateTimelineTuple_).measMap_.size();
+      double lastImageTime;
+      if(std::get<0>(mpFilter_->updateTimelineTuple_).getLastTime(lastImageTime)){
+        mpFilter_->updateSafe(&lastImageTime);
+      }
       const double t2 = (double) cv::getTickCount();
       int c2 = std::get<0>(mpFilter_->updateTimelineTuple_).measMap_.size();
       timing_T += (t2-t1)/cv::getTickFrequency()*1000;
@@ -625,7 +628,7 @@ class RovioNode{
         // Send Map (Pose Sensor, I) to World (rovio-intern, W) transformation
         if(mpPoseUpdate_->inertialPoseIndex_ >=0){
           Eigen::Vector3d IrIW = state.poseLin(mpPoseUpdate_->inertialPoseIndex_);
-          rot::RotationQuaternionPD qWI = state.poseRot(mpPoseUpdate_->inertialPoseIndex_);
+          QPD qWI = state.poseRot(mpPoseUpdate_->inertialPoseIndex_);
           tf::StampedTransform tf_transform_WI;
           tf_transform_WI.frame_id_ = map_frame_;
           tf_transform_WI.child_frame_id_ = world_frame_;

--- a/include/rovio/RovioNode.hpp
+++ b/include/rovio/RovioNode.hpp
@@ -513,8 +513,10 @@ class RovioNode{
   void groundtruthCallback(const geometry_msgs::TransformStamped::ConstPtr& transform){
     std::lock_guard<std::mutex> lock(m_filter_);
     if(init_state_.isInitialized()){
-      poseUpdateMeas_.pos() = Eigen::Vector3d(transform->transform.translation.x,transform->transform.translation.y,transform->transform.translation.z);
-      poseUpdateMeas_.att() = QPD(transform->transform.rotation.w,transform->transform.rotation.x,transform->transform.rotation.y,transform->transform.rotation.z);
+      Eigen::Vector3d JrJV(transform->transform.translation.x,transform->transform.translation.y,transform->transform.translation.z);
+      poseUpdateMeas_.pos() = JrJV;
+      QPD qJV(transform->transform.rotation.w,transform->transform.rotation.x,transform->transform.rotation.y,transform->transform.rotation.z);
+      poseUpdateMeas_.att() = qJV.inverted();
       mpFilter_->template addUpdateMeas<1>(poseUpdateMeas_,transform->header.stamp.toSec()+mpPoseUpdate_->timeOffset_);
       updateAndPublish();
     }
@@ -534,9 +536,9 @@ class RovioNode{
                                   rovio::SrvResetToPose::Response& /*response*/){
     V3D WrWM(request.T_IW.position.x, request.T_IW.position.y,
              request.T_IW.position.z);
-    QPD qMW(request.T_IW.orientation.w, request.T_IW.orientation.x,
+    QPD qWM(request.T_IW.orientation.w, request.T_IW.orientation.x,
             request.T_IW.orientation.y, request.T_IW.orientation.z);
-    requestResetToPose(WrWM, qMW);
+    requestResetToPose(WrWM, qWM.inverted());
     return true;
   }
 
@@ -634,7 +636,7 @@ class RovioNode{
           tf_transform_WI.child_frame_id_ = world_frame_;
           tf_transform_WI.stamp_ = ros::Time(mpFilter_->safe_.t_);
           tf_transform_WI.setOrigin(tf::Vector3(IrIW(0),IrIW(1),IrIW(2)));
-          tf_transform_WI.setRotation(tf::Quaternion(qWI.x(),qWI.y(),qWI.z(),qWI.w()));
+          tf_transform_WI.setRotation(tf::Quaternion(qWI.x(),qWI.y(),qWI.z(),-qWI.w()));
           tb_.sendTransform(tf_transform_WI);
         }
 
@@ -644,7 +646,7 @@ class RovioNode{
         tf_transform_MW.child_frame_id_ = imu_frame_;
         tf_transform_MW.stamp_ = ros::Time(mpFilter_->safe_.t_);
         tf_transform_MW.setOrigin(tf::Vector3(imuOutput_.WrWB()(0),imuOutput_.WrWB()(1),imuOutput_.WrWB()(2)));
-        tf_transform_MW.setRotation(tf::Quaternion(imuOutput_.qBW().x(),imuOutput_.qBW().y(),imuOutput_.qBW().z(),imuOutput_.qBW().w()));
+        tf_transform_MW.setRotation(tf::Quaternion(imuOutput_.qBW().x(),imuOutput_.qBW().y(),imuOutput_.qBW().z(),-imuOutput_.qBW().w()));
         tb_.sendTransform(tf_transform_MW);
 
         // Send camera pose.
@@ -654,7 +656,7 @@ class RovioNode{
           tf_transform_CM.child_frame_id_ = camera_frame_ + std::to_string(camID);
           tf_transform_CM.stamp_ = ros::Time(mpFilter_->safe_.t_);
           tf_transform_CM.setOrigin(tf::Vector3(state.MrMC(camID)(0),state.MrMC(camID)(1),state.MrMC(camID)(2)));
-          tf_transform_CM.setRotation(tf::Quaternion(state.qCM(camID).x(),state.qCM(camID).y(),state.qCM(camID).z(),state.qCM(camID).w()));
+          tf_transform_CM.setRotation(tf::Quaternion(state.qCM(camID).x(),state.qCM(camID).y(),state.qCM(camID).z(),-state.qCM(camID).w()));
           tb_.sendTransform(tf_transform_CM);
         }
 
@@ -668,7 +670,7 @@ class RovioNode{
           odometryMsg_.pose.pose.position.x = imuOutput_.WrWB()(0);
           odometryMsg_.pose.pose.position.y = imuOutput_.WrWB()(1);
           odometryMsg_.pose.pose.position.z = imuOutput_.WrWB()(2);
-          odometryMsg_.pose.pose.orientation.w = imuOutput_.qBW().w();
+          odometryMsg_.pose.pose.orientation.w = -imuOutput_.qBW().w();
           odometryMsg_.pose.pose.orientation.x = imuOutput_.qBW().x();
           odometryMsg_.pose.pose.orientation.y = imuOutput_.qBW().y();
           odometryMsg_.pose.pose.orientation.z = imuOutput_.qBW().z();
@@ -709,7 +711,7 @@ class RovioNode{
           transformMsg_.transform.rotation.x = imuOutput_.qBW().x();
           transformMsg_.transform.rotation.y = imuOutput_.qBW().y();
           transformMsg_.transform.rotation.z = imuOutput_.qBW().z();
-          transformMsg_.transform.rotation.w = imuOutput_.qBW().w();
+          transformMsg_.transform.rotation.w = -imuOutput_.qBW().w();
           pubTransform_.publish(transformMsg_);
         }
 
@@ -724,7 +726,7 @@ class RovioNode{
             extrinsicsMsg_[camID].pose.pose.orientation.x = state.qCM(camID).x();
             extrinsicsMsg_[camID].pose.pose.orientation.y = state.qCM(camID).y();
             extrinsicsMsg_[camID].pose.pose.orientation.z = state.qCM(camID).z();
-            extrinsicsMsg_[camID].pose.pose.orientation.w = state.qCM(camID).w();
+            extrinsicsMsg_[camID].pose.pose.orientation.w = -state.qCM(camID).w();
             for(unsigned int i=0;i<6;i++){
               unsigned int ind1 = mtState::template getId<mtState::_vep>(camID)+i;
               if(i>=3) ind1 = mtState::template getId<mtState::_vea>(camID)+i-3;

--- a/include/rovio/RovioScene.hpp
+++ b/include/rovio/RovioScene.hpp
@@ -33,8 +33,6 @@
 #include "rovio/Scene.hpp"
 #include <memory>
 
-namespace rot = kindr::rotations::eigen_impl;
-
 namespace rovio {
 
 template<typename FILTER>

--- a/include/rovio/Scene.hpp
+++ b/include/rovio/Scene.hpp
@@ -72,16 +72,16 @@ static bool ReadShaderFile(const char* pFileName, std::string& outFile){
   return ret;
 }
 
-static Eigen::Matrix4f InitTransform(const Eigen::Vector3f& v,const rot::RotationQuaternionPF& q){
+static Eigen::Matrix4f InitTransform(const Eigen::Vector3f& v,const kindr::RotationQuaternionPF& q){
   Eigen::Matrix4f m = Eigen::Matrix4f::Identity();
-  m.block<3,3>(0,0) = rot::RotationMatrixPF(q).matrix();
+  m.block<3,3>(0,0) = kindr::RotationMatrixPF(q).matrix();
   m.block<3,1>(0,3) = -q.rotate(v);
   return m;
 }
 
-static Eigen::Matrix4f InitInverseTransform(const Eigen::Vector3f& v,const rot::RotationQuaternionPF& q){
+static Eigen::Matrix4f InitInverseTransform(const Eigen::Vector3f& v,const kindr::RotationQuaternionPF& q){
   Eigen::Matrix4f m = Eigen::Matrix4f::Identity();
-  m.block<3,3>(0,0) = rot::RotationMatrixPF(q).inverted().matrix();
+  m.block<3,3>(0,0) = kindr::RotationMatrixPF(q).inverted().matrix();
   m.block<3,1>(0,3) = v;
   return m;
 }
@@ -172,7 +172,7 @@ class SceneObject{
   void CalcNormals();
   void loadOptions();
   Eigen::Vector3f W_r_WB_;
-  rot::RotationQuaternionPF q_BW_;
+  kindr::RotationQuaternionPF q_BW_;
   std::vector<Vertex> vertices_;
   std::vector<unsigned int> indices_;
   GLuint VBO_;
@@ -226,7 +226,7 @@ class Scene{
   DirectionalLight mDirectionalLight_;
 
   Eigen::Vector3f W_r_WC_;
-  rot::RotationQuaternionPF q_CW_;
+  kindr::RotationQuaternionPF q_CW_;
 
   Eigen::Matrix4f C_TF_W_;
   Eigen::Matrix4f V_TF_C_;

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -431,22 +431,22 @@ namespace rovio{
   }
   void Scene::setView(const Eigen::Vector3f& pos, const Eigen::Vector3f& target){
     W_r_WC_ = pos;
-    q_CW_.setFromVectors(Eigen::Vector3f(0.0f,0.0f,-1.0f),Eigen::Vector3f(target-pos));
+    q_CW_.setFromVectors(Eigen::Vector3f(target-pos),Eigen::Vector3f(0.0f,0.0f,-1.0f));
   }
   void Scene::setYDown(float step){
     float min = 1.0f;
     float minAng = 0.0;
     float angle = 0.0;
-    rot::RotationQuaternionPF q;
+    kindr::RotationQuaternionPF q;
     while(angle<=2*M_PI){
-      q = rot::EulerAnglesYprPF(angle,0,0);
+      q = kindr::EulerAnglesYprPF(angle,0,0);
       if((q*q_CW_).inverseRotate(Eigen::Vector3f(0,-1,0))(2) < min){
         minAng = angle;
         min = (q*q_CW_).inverseRotate(Eigen::Vector3f(0,-1,0))(2);
       }
       angle += step;
     }
-    q_CW_ = rot::EulerAnglesYprPF(minAng,0,0)*q_CW_;
+    q_CW_ = kindr::EulerAnglesYprPF(minAng,0,0)*q_CW_;
   }
   void Scene::SpecialKeyboardCB(int Key, int x, int y)
   {
@@ -477,8 +477,8 @@ namespace rovio{
 
       Eigen::Vector3f vec;
       vec.setZero();
-      vec(0) = -(float)DeltaY / 50.0f;
-      vec(1) = -(float)DeltaX/ 50.0f;
+      vec(0) = (float)DeltaY / 50.0f;
+      vec(1) = (float)DeltaX / 50.0f;
 
       q_CW_ = q_CW_.boxPlus(vec);
       q_CW_.fix();


### PR DESCRIPTION
Adapted to the new conventions in kindr1. This means that everything is now based on the Hamilton quaternion convention which implies various sign changes. For users this means that all quaternions (e.g. camera-IMU calibration) must now be provided using the Hamilton convention (switch sign of w compared to before) and that the output is also Hamilton.

Two tuning parameters have been changed:
- initCovFeature_0 is now 0.5 in order to improve stability when lacking motion (the covariance should still be large enough to avoid to strong biasing, e.g., 0 which is infinity is still in the 1-sigma bound).
- penaltyDistance is now 100 in order to improve the distribution of the features within the image. This is beneficial in outdoor scenarios where up to now features tended to stick onto the horizon.