### PR TITLE
Pose update (with per-measurement covariance) from Odometry message

### DIFF
--- a/cfg/rovio.info
+++ b/cfg/rovio.info
@@ -198,6 +198,7 @@ PoseUpdate
 	noFeedbackToRovio true;						By default the pose update is only used for aligning coordinate frame. Set to false if ROVIO should benefit frome the posed measurements.
 	doInertialAlignmentAtStart true;			Should the transformation between I and W be explicitly computed and set with the first pose measurement.
 	timeOffset 0.0;								Time offset added to the pose measurement timestamps
+    useOdometryPoseCov false;                    Should the UpdateNoise position covariance be scaled using the covariance in the Odometry message
     qVM_x 0;									X-entry of quaterion representing IMU to reference body coordinate frame of pose measurement (Hamilton)
     qVM_y 0;									Y-entry of quaterion representing IMU to reference body coordinate frame of pose measurement (Hamilton)
     qVM_z 0;									Z-entry of quaterion representing IMU to reference body coordinate frame of pose measurement (Hamilton)

--- a/cfg/rovio.info
+++ b/cfg/rovio.info
@@ -198,7 +198,7 @@ PoseUpdate
 	noFeedbackToRovio true;						By default the pose update is only used for aligning coordinate frame. Set to false if ROVIO should benefit frome the posed measurements.
 	doInertialAlignmentAtStart true;			Should the transformation between I and W be explicitly computed and set with the first pose measurement.
 	timeOffset 0.0;								Time offset added to the pose measurement timestamps
-    useOdometryPoseCov false;                    Should the UpdateNoise position covariance be scaled using the covariance in the Odometry message
+    useOdometryCov false;                    Should the UpdateNoise position covariance be scaled using the covariance in the Odometry message
     qVM_x 0;									X-entry of quaterion representing IMU to reference body coordinate frame of pose measurement (Hamilton)
     qVM_y 0;									Y-entry of quaterion representing IMU to reference body coordinate frame of pose measurement (Hamilton)
     qVM_z 0;									Z-entry of quaterion representing IMU to reference body coordinate frame of pose measurement (Hamilton)

--- a/include/rovio/PoseUpdate.hpp
+++ b/include/rovio/PoseUpdate.hpp
@@ -60,8 +60,10 @@ class PoseUpdateMeas: public LWF::State<LWF::VectorElement<3>,LWF::QuaternionEle
  public:
   static constexpr unsigned int _pos = 0;
   static constexpr unsigned int _att = _pos+1;
+  M3D pos_cov_; // Will be used to scale the update covariance according to the measurement
   PoseUpdateMeas(){
     static_assert(_att+1==E_,"Error with indices");
+    pos_cov_.setIdentity();
   };
   virtual ~PoseUpdateMeas(){};
   inline V3D& pos(){
@@ -75,6 +77,12 @@ class PoseUpdateMeas: public LWF::State<LWF::VectorElement<3>,LWF::QuaternionEle
   }
   inline const QPD& att() const{
     return this->template get<_att>();
+  }
+  inline M3D& pos_cov(){
+    return pos_cov_;
+  }
+  inline const M3D& pos_cov() const{
+    return pos_cov_;
   }
 };
 class PoseUpdateNoise: public LWF::State<LWF::VectorElement<3>,LWF::VectorElement<3>>{

--- a/include/rovio/RovioNode.hpp
+++ b/include/rovio/RovioNode.hpp
@@ -537,8 +537,8 @@ class RovioNode{
       QPD qJV(odometry->pose.pose.orientation.w,odometry->pose.pose.orientation.x,odometry->pose.pose.orientation.y,odometry->pose.pose.orientation.z);
       poseUpdateMeas_.att() = qJV.inverted();
 
-      const Eigen::Matrix<double,6,6> full_cov = Eigen::Map<const Eigen::Matrix<double,6,6,Eigen::RowMajor>>(odometry->pose.covariance.data());
-      poseUpdateMeas_.pos_cov() = full_cov.template block<3,3>(0, 0);
+      const Eigen::Matrix<double,6,6> measuredCov = Eigen::Map<const Eigen::Matrix<double,6,6,Eigen::RowMajor>>(odometry->pose.covariance.data());
+      poseUpdateMeas_.measuredCov() = measuredCov;
 
       mpFilter_->template addUpdateMeas<1>(poseUpdateMeas_,odometry->header.stamp.toSec()+mpPoseUpdate_->timeOffset_);
       updateAndPublish();

--- a/include/rovio/RovioNode.hpp
+++ b/include/rovio/RovioNode.hpp
@@ -533,8 +533,13 @@ class RovioNode{
     if(init_state_.isInitialized()) {
       Eigen::Vector3d JrJV(odometry->pose.pose.position.x,odometry->pose.pose.position.y,odometry->pose.pose.position.z);
       poseUpdateMeas_.pos() = JrJV;
+      
       QPD qJV(odometry->pose.pose.orientation.w,odometry->pose.pose.orientation.x,odometry->pose.pose.orientation.y,odometry->pose.pose.orientation.z);
       poseUpdateMeas_.att() = qJV.inverted();
+
+      const Eigen::Matrix<double,6,6> full_cov = Eigen::Map<const Eigen::Matrix<double,6,6,Eigen::RowMajor>>(odometry->pose.covariance.data());
+      poseUpdateMeas_.pos_cov() = full_cov.template block<3,3>(0, 0);
+
       mpFilter_->template addUpdateMeas<1>(poseUpdateMeas_,odometry->header.stamp.toSec()+mpPoseUpdate_->timeOffset_);
       updateAndPublish();
     }


### PR DESCRIPTION
This PR adds PoseUpdate input from nav_msgs::Odometry messages.

When using GPS, it's useful to correct the update covariance depending on the value reported by the receiver. To do this, this PR adds optional scaling of the configured pose update covariance by the value in the odometry message. This behavior is controlled by the new `useOdometryPoseCov` flag in the .info file.

Notes:
- I've decided to keep the configured value as a scaling factor to make "optimistic" or "pessimistic" receivers easier to handle.
- I've only added support for scaling position covariance, for the common case of GPS. I can add a second flag for attitude if needed.

@mhkabir