### PR TITLE
Reset service field name updated with current frame names conventions

### DIFF
--- a/include/rovio/RovioNode.hpp
+++ b/include/rovio/RovioNode.hpp
@@ -557,10 +557,10 @@ class RovioNode{
    */
   bool resetToPoseServiceCallback(rovio::SrvResetToPose::Request& request,
                                   rovio::SrvResetToPose::Response& /*response*/){
-    V3D WrWM(request.T_IW.position.x, request.T_IW.position.y,
-             request.T_IW.position.z);
-    QPD qWM(request.T_IW.orientation.w, request.T_IW.orientation.x,
-            request.T_IW.orientation.y, request.T_IW.orientation.z);
+    V3D WrWM(request.T_WM.position.x, request.T_WM.position.y,
+             request.T_WM.position.z);
+    QPD qWM(request.T_WM.orientation.w, request.T_WM.orientation.x,
+            request.T_WM.orientation.y, request.T_WM.orientation.z);
     requestResetToPose(WrWM, qWM.inverted());
     return true;
   }

--- a/srv/SrvResetToPose.srv
+++ b/srv/SrvResetToPose.srv
@@ -1,5 +1,7 @@
-# Initial pose after reset. T_IW takes points from world coordinates to IMU
-# coordinates: I_p = T_IW * W_p
-geometry_msgs/Pose T_IW
+# Initial IMU pose after reset.
+# T_WM transforms points from IMU frame (M) to World frame (W)
+# Conventions: W_p = T_WM * M_p
+# Check wiki page "Coordinate Frames and Notation" for more information about frames
+geometry_msgs/Pose T_WM
 ---
 std_msgs/Empty nothing


### PR DESCRIPTION
@bloesch : @raghavkhanna  and I found a mismatch about the convention used in the field of the reset with external pose service.
Now name convention follows guidelines shown in [Coordinate-Frames-and-Notation](https://github.com/ethz-asl/rovio/wiki/Coordinate-Frames-and-Notation)