### PR TITLE
Feature/age reject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,6 @@ add_definitions(-DROVIO_NCAM=${ROVIO_NCAM})
 add_definitions(-DROVIO_NLEVELS=${ROVIO_NLEVELS})
 add_definitions(-DROVIO_PATCHSIZE=${ROVIO_PATCHSIZE})
 add_definitions(-DROVIO_NPOSE=${ROVIO_NPOSE})
-add_definitions(-DEIGEN_DONT_VECTORIZE)
-add_definitions(-DEIGEN_DISABLE_UNALIGNED_ARRAY_ASSERT)
 
 add_subdirectory(lightweight_filtering)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ add_definitions(-DROVIO_NCAM=${ROVIO_NCAM})
 add_definitions(-DROVIO_NLEVELS=${ROVIO_NLEVELS})
 add_definitions(-DROVIO_PATCHSIZE=${ROVIO_PATCHSIZE})
 add_definitions(-DROVIO_NPOSE=${ROVIO_NPOSE})
+add_definitions(-DEIGEN_DONT_VECTORIZE)
+add_definitions(-DEIGEN_DISABLE_UNALIGNED_ARRAY_ASSERT)
 
 add_subdirectory(lightweight_filtering)
 

--- a/include/rovio/FeatureStatistics.hpp
+++ b/include/rovio/FeatureStatistics.hpp
@@ -324,13 +324,17 @@ class FeatureStatistics{
    * @param localVisibilityRange local range for visibility quality
    * @param upper                if the global quality is bad (0) than the combination of local and visibility quality must be above this
    * @param lower                if the global quality is very good (1) than the combination of local and visibility quality must be above this
+   * @param maxCount             the maximum number of frames a feature can exist for and still be considered good
    * @return whether this is a good feature or not
-   * @todo consider information quality (neibours, shape)
+   * @todo consider information quality (neighbors, shape)
    */
-  bool isGoodFeature(const double upper = 0.8, const double lower = 0.1) const{
+  bool isGoodFeature(const double upper = 0.8, const double lower = 0.1, const int maxCount = 10000) const{
     bool isGood = false;
     for(int i=0;i<nCam;i++){
       isGood = isGood | getLocalQuality(i)*getLocalVisibility(i) > upper-(upper-lower)*getGlobalQuality();
+    }
+    if(totCount_ > maxCount){
+      isGood = false;
     }
     return isGood;
   }

--- a/include/rovio/ImgUpdate.hpp
+++ b/include/rovio/ImgUpdate.hpp
@@ -196,6 +196,7 @@ ImgOutlierDetection<typename FILTERSTATE::mtState>,false>{
   double penaltyDistance_;
   double zeroDistancePenalty_;
   double trackingUpperBound_,trackingLowerBound_;
+  int maxFeatureFrames_;
   double minTrackedAndFreeFeatures_;
   double minRelativeSTScore_;
   double minAbsoluteSTScore_;
@@ -285,6 +286,7 @@ ImgOutlierDetection<typename FILTERSTATE::mtState>,false>{
     verbose_ = false;
     trackingUpperBound_ = 0.9;
     trackingLowerBound_ = 0.1;
+    maxFeatureFrames_ = 10000;
     minTrackedAndFreeFeatures_ = 0.5;
     minRelativeSTScore_ = 0.2;
     minAbsoluteSTScore_ = 0.2;
@@ -336,6 +338,7 @@ ImgOutlierDetection<typename FILTERSTATE::mtState>,false>{
     intRegister_.registerScalar("nDetectionBuckets",nDetectionBuckets_);
     intRegister_.registerScalar("MotionDetection.minFeatureCountForNoMotionDetection",minFeatureCountForNoMotionDetection_);
     intRegister_.registerScalar("alignMaxUniSample",alignMaxUniSample_);
+    intRegister_.registerScalar("maxFeatureFrames",maxFeatureFrames_);
     boolRegister_.registerScalar("MotionDetection.isEnabled",doVisualMotionDetection_);
     boolRegister_.registerScalar("useDirectMethod",useDirectMethod_);
     boolRegister_.registerScalar("doFrameVisualisation",doFrameVisualisation_);
@@ -941,7 +944,7 @@ ImgOutlierDetection<typename FILTERSTATE::mtState>,false>{
     for(unsigned int i=0;i<mtState::nMax_;i++){
       if(filterState.fsm_.isValid_[i]){
         FeatureManager<mtState::nLevels_,mtState::patchSize_,mtState::nCam_>& f = filterState.fsm_.features_[i];
-        if(!f.mpStatistics_->isGoodFeature(trackingUpperBound_,trackingLowerBound_)){
+        if(!f.mpStatistics_->isGoodFeature(trackingUpperBound_,trackingLowerBound_, maxFeatureFrames_)){
           if(verbose_) std::cout << filterState.fsm_.features_[i].idx_ << ", ";
           filterState.fsm_.isValid_[i] = false;
           filterState.resetFeatureCovariance(i,Eigen::Matrix3d::Identity());
@@ -956,7 +959,7 @@ ImgOutlierDetection<typename FILTERSTATE::mtState>,false>{
     while((int)(mtState::nMax_) - (int)(filterState.fsm_.getValidCount()) < requiredFreeFeature){
       if(filterState.fsm_.isValid_[featureIndex]){
         FeatureManager<mtState::nLevels_,mtState::patchSize_,mtState::nCam_>& f = filterState.fsm_.features_[featureIndex];
-        if(!f.mpStatistics_->trackedInSomeFrame() && !f.mpStatistics_->isGoodFeature(trackingUpperBound_*factor,trackingLowerBound_*factor)){
+        if(!f.mpStatistics_->trackedInSomeFrame() && !f.mpStatistics_->isGoodFeature(trackingUpperBound_*factor,trackingLowerBound_*factor, maxFeatureFrames_)){
           if(verbose_) std::cout << filterState.fsm_.features_[featureIndex].idx_ << ", ";
           filterState.fsm_.isValid_[featureIndex] = false;
           filterState.resetFeatureCovariance(featureIndex,Eigen::Matrix3d::Identity());

--- a/src/test_mlp.cpp
+++ b/src/test_mlp.cpp
@@ -199,7 +199,7 @@ TEST_F(MLPTesting, statistics) {
   ASSERT_EQ(stat_.localQuality_[0],localQuality[0]);
   ASSERT_EQ(stat_.localQuality_[1],localQuality[1]);
   ASSERT_EQ(stat_.getGlobalQuality(),6.0/10.0);
-  ASSERT_EQ(stat_.isGoodFeature(0.9,0.1),true);
+  ASSERT_EQ(stat_.isGoodFeature(0.9,0.1,10000),true);
 }
 
 // Test isMultilevelPatchInFrame


### PR DESCRIPTION
Added ability to reject features if they are over a certain age. Seems to correct some of the state estimation issues we have been having when flying long straight paths, but will need to do a real world test. @marco-tranzatto @bloesch 