### PR TITLE
Initialize offdiagonals of update covariance to zero.

### DIFF
--- a/include/rovio/PoseUpdate.hpp
+++ b/include/rovio/PoseUpdate.hpp
@@ -162,6 +162,7 @@ class PoseUpdate: public LWF::Update<PoseInnovation,FILTERSTATE,PoseUpdateMeas,P
     MrMV_.setZero();
     qWI_.setIdentity();
     IrIW_.setZero();
+    defaultUpdnoiP_.setZero();
     timeOffset_ = 0.0;
     enablePosition_ = true;
     enableAttitude_ = true;


### PR DESCRIPTION
We have tracked down a bug in the PoseUpdate that gave us a weird behaviour and might be related to ethz-asl/rovio#112. The problem is that the offdiagonals of the update covariance are not initialized to zero and contained random values.


Backport from https://github.com/ethz-asl/maplab_rovio/pull/14