### PR TITLE
add double sphere distortion model

### DIFF
--- a/include/rovio/Camera.hpp
+++ b/include/rovio/Camera.hpp
@@ -41,7 +41,8 @@ class Camera{
    * */
   enum ModelType{
     RADTAN,    //!< Radial tangential distortion model.
-    EQUIDIST   //!< Equidistant distortion model.
+    EQUIDIST,  //!< Equidistant distortion model.
+    DS         //!< Double sphere distortion model.
   } type_;
 
   Eigen::Matrix3d K_; //!< Intrinsic parameter matrix.
@@ -50,6 +51,11 @@ class Camera{
   /** \brief Distortion Parameter. */
   double k1_,k2_,k3_,k4_,k5_,k6_;
   double p1_,p2_,s1_,s2_,s3_,s4_;
+  //@}
+
+  //@{
+  /** \brief Radius (as ratio of images shortest side) within which features can be initalized. */
+  double valid_radius_;
   //@}
 
   /** \brief Constructor.
@@ -80,6 +86,12 @@ class Camera{
    *   @param filename - Path to the yaml-file, containing the distortion coefficients.
    */
   void loadEquidist(const std::string& filename);
+
+  /** \brief Loads and sets the distortion parameters {k1_, k2_} for the Double Sphere distortion model from
+   *         yaml-file.
+   *   @param filename - Path to the yaml-file, containing the distortion coefficients.
+   */
+  void loadDoubleSphere(const std::string& filename);
 
   /** \brief Loads and sets the distortion model and the corresponding distortion coefficients from yaml-file.
    *
@@ -118,6 +130,22 @@ class Camera{
    *   @param J   - Jacobian matrix of the distortion process (input to output).
    */
   void distortEquidist(const Eigen::Vector2d& in, Eigen::Vector2d& out, Eigen::Matrix2d& J) const;
+
+  /** \brief Distorts a point on the unit plane (in camera coordinates) according to the Double Sphere distortion model.
+   *
+   *   @param in  - Undistorted point coordinates on the unit plane (in camera coordinates).
+   *   @param out - Distorted point coordinates on the unit plane (in camera coordinates).
+   */
+  void distortDoubleSphere(const Eigen::Vector2d& in, Eigen::Vector2d& out) const;
+
+  /** \brief Distorts a point on the unit plane (in camera coordinates) according to the Double Sphere distortion model
+   *         and outputs additionally the corresponding jacobian matrix (input to output).
+   *
+   *   @param in  - Undistorted point coordinates on the unit plane (in camera coordinates).
+   *   @param out - Distorted point coordinates on the unit plane (in camera coordinates).
+   *   @param J   - Jacobian matrix of the distortion process (input to output).
+   */
+  void distortDoubleSphere(const Eigen::Vector2d& in, Eigen::Vector2d& out, Eigen::Matrix2d& J) const;
 
   /** \brief Distorts a point on the unit plane, according to the set distortion model (#ModelType) and to the set
    *         distortion coefficients.

--- a/include/rovio/ImagePyramid.hpp
+++ b/include/rovio/ImagePyramid.hpp
@@ -144,8 +144,18 @@ class ImagePyramid{
     auto feature_detector_fast = cv::FastFeatureDetector::create(detectionThreshold, true);
     feature_detector_fast->detect(imgs_[l], keypoints);
 #endif
+
     candidates.reserve(candidates.size()+keypoints.size());
     for (auto it = keypoints.cbegin(), end = keypoints.cend(); it != end; ++it) {
+
+      const double x_dist = it->pt.x - imgs_[l].cols/2.0;
+      const double y_dist = it->pt.y - imgs_[l].rows/2.0;
+      const double max_valid_dist = valid_radius*std::min(imgs_[l].cols, imgs_[l].rows);
+
+      if((x_dist*x_dist + y_dist*y_dist) > (max_valid_dist*max_valid_dist)){
+        continue;
+      }
+
       candidates.push_back(
               levelTranformCoordinates(FeatureCoordinates(cv::Point2f(it->pt.x, it->pt.y)),l,0));
     }

--- a/include/rovio/ImagePyramid.hpp
+++ b/include/rovio/ImagePyramid.hpp
@@ -134,8 +134,9 @@ class ImagePyramid{
    * @param l                  - Pyramid level at which the corners should be extracted.
    * @param detectionThreshold - Detection threshold of the used cv::FastFeatureDetector.
    *                             See http://docs.opencv.org/trunk/df/d74/classcv_1_1FastFeatureDetector.html
+   * @param valid_radius       - Radius inside which a feature is considered valid (as ratio of shortest image side)
    */
-  void detectFastCorners(FeatureCoordinatesVec & candidates, int l, int detectionThreshold) const{
+  void detectFastCorners(FeatureCoordinatesVec & candidates, int l, int detectionThreshold, double valid_radius = std::numeric_limits<double>::max()) const{
     std::vector<cv::KeyPoint> keypoints;
 #if (CV_MAJOR_VERSION < 3)
     cv::FastFeatureDetector feature_detector_fast(detectionThreshold, true);

--- a/include/rovio/ImgUpdate.hpp
+++ b/include/rovio/ImgUpdate.hpp
@@ -985,7 +985,7 @@ ImgOutlierDetection<typename FILTERSTATE::mtState>,false>{
         const double t1 = (double) cv::getTickCount();
         candidates_.clear();
         for(int l=endLevel_;l<=startLevel_;l++){
-          meas.aux().pyr_[camID].detectFastCorners(candidates_,l,fastDetectionThreshold_);
+          meas.aux().pyr_[camID].detectFastCorners(candidates_,l,fastDetectionThreshold_, mpMultiCamera_->cameras_[camID].valid_radius_);
         }
         const double t2 = (double) cv::getTickCount();
         if(verbose_) std::cout << "== Detected " << candidates_.size() << " on levels " << endLevel_ << "-" << startLevel_ << " (" << (t2-t1)/cv::getTickFrequency()*1000 << " ms)" << std::endl;

--- a/include/rovio/MultiCamera.hpp
+++ b/include/rovio/MultiCamera.hpp
@@ -71,7 +71,7 @@ class MultiCamera{
    *   @param filename - Path to the yaml-file, containing the distortion model and distortion coefficient data.
    */
   void load(const int i, const std::string& filename){
-    cameras_[i].load(filename, valid_radius);
+    cameras_[i].load(filename);
   }
 
   /** \brief Transforms feature coordinates from one camera frame to another

--- a/include/rovio/MultiCamera.hpp
+++ b/include/rovio/MultiCamera.hpp
@@ -71,7 +71,7 @@ class MultiCamera{
    *   @param filename - Path to the yaml-file, containing the distortion model and distortion coefficient data.
    */
   void load(const int i, const std::string& filename){
-    cameras_[i].load(filename);
+    cameras_[i].load(filename, valid_radius);
   }
 
   /** \brief Transforms feature coordinates from one camera frame to another

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -175,7 +175,7 @@ namespace rovio{
       const double d1 = std::sqrt(x2 + y2 + 1.0);
       const double d2 = std::sqrt(x2 + y2 + (k1_*d1 + 1.0)*(k1_*d1 + 1.0));
       const double scaling = 1.0f/(k2_*d2 + (1-k2_)*(k1_*d1+1.0));
-      
+
       out(0) = in(0) * scaling;
       out(1) = in(1) * scaling;
   }
@@ -194,14 +194,14 @@ namespace rovio{
     const double d1 = std::sqrt(x2 + y2 + 1.0);
     const double d2 = std::sqrt(x2 + y2 + (k1_*d1 + 1.0)*(k1_*d1 + 1.0));
     const double s = 1.0f/(k2_*d2 + (1-k2_)*(k1_*d1+1.0));
-    
+
     out(0) = in(0) * s;
     out(1) = in(1) * s;
 
     const double d1dx = in(0)/d1;
     const double d1dy = in(1)/d1;
-    const double d2dx = (2.0*in(0) + 2.0*d1dx*k1_*(d1*k1_ + 1.0))/(2.0*d2);
-    const double d2dy = (2.0*in(1) + 2.0*d1dy*k1_*(d1*k1_ + 1.0))/(2.0*d2);
+    const double d2dx = (in(0) + d1dx*k1_*(d1*k1_ + 1.0))/(d2);
+    const double d2dy = (in(1) + d1dy*k1_*(d1*k1_ + 1.0))/(d2);
 
     J(0,0) = -in(0)*(d2dx*k2_ - d1dx*k1_*(k2_ - 1.0))*s*s + s;
     J(0,1) = -s*s*in(0)*(d2dy*k2_ - d1dy*k1_*(k2_ - 1.0));


### PR DESCRIPTION
Added double sphere distortion model (now also in kalibr) to allow rovio to work with exteremly fish-eyed cameras.
Also added an optional setting to specify a radius to consider new keypoints inside. Without this rovio would place points past the 180 degree point in the image and they would initialize at the images center.

Someone should probably check the jacobians, as this is far from my strong suit

![ezgif-2-3bd331eff4](https://user-images.githubusercontent.com/730680/45231326-f1d25a00-b2cb-11e8-861f-e57325e47f9d.gif)
