### PR TITLE
Add an optional image mask for feature detections

### DIFF
--- a/include/rovio/ImageMask.hpp
+++ b/include/rovio/ImageMask.hpp
@@ -63,10 +63,16 @@ class ImageMask {
     }
     // Ugly or nice -- up to you. Write a lambda that looks up each feature in
     // the mask to decide if it should be erased.
+    // Values above 0 are kept, all values with 0 are erased from the feature
+    // vector like they never existed.
     feature_vec->erase(
         std::remove_if(feature_vec->begin(), feature_vec->end(),
-                       [](const FeatureCoordinates& feature_coord) {
-                         return false;
+                       [this](const FeatureCoordinates& feature_coord) -> bool {
+                         uint8_t mask_val = mask_.at<uint8_t>(feature_coord.c_);
+                         if (mask_val > 0) {
+                           return false;
+                         }
+                         return true;
                        }),
         feature_vec->end());
   }

--- a/include/rovio/ImageMask.hpp
+++ b/include/rovio/ImageMask.hpp
@@ -1,0 +1,80 @@
+/*
+* Copyright (c) 2014, Autonomous Systems Lab
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+* * Redistributions of source code must retain the above copyright
+* notice, this list of conditions and the following disclaimer.
+* * Redistributions in binary form must reproduce the above copyright
+* notice, this list of conditions and the following disclaimer in the
+* documentation and/or other materials provided with the distribution.
+* * Neither the name of the Autonomous Systems Lab, ETH Zurich nor the
+* names of its contributors may be used to endorse or promote products
+* derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+*/
+
+#ifndef ROVIO_IMAGE_MASK_HPP_
+#define ROVIO_IMAGE_MASK_HPP_
+
+#include <algorithm>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include "rovio/FeatureCoordinates.hpp"
+
+namespace rovio {
+
+class ImageMask {
+ public:
+  ImageMask() {}
+
+  // Loads an image mask. White = ok, black = don't detect features.
+  bool loadImage(const std::string& image_path) {
+    mask_ = cv::imread(image_path, CV_LOAD_IMAGE_GRAYSCALE);
+    if (!mask_.data) {
+      std::cout << "Couldn't load image mask from path: " << image_path
+                << std::endl;
+      return false;
+    }
+    std::cout << "Successfully loaded image mask from path: " << image_path
+              << std::endl;
+    return true;
+  }
+
+  // Prunes feature vector, removing any features detected in the *black* region
+  // of the mask.
+  void pruneFeatureVector(FeatureCoordinatesVec* feature_vec) const {
+    if (!mask_.data) {
+      return;
+    }
+    // Ugly or nice -- up to you. Write a lambda that looks up each feature in
+    // the mask to decide if it should be erased.
+    feature_vec->erase(
+        std::remove_if(feature_vec->begin(), feature_vec->end(),
+                       [](const FeatureCoordinates& feature_coord) {
+                         return false;
+                       }),
+        feature_vec->end());
+  }
+
+ private:
+  cv::Mat mask_;
+};
+
+}  // namespace rovio
+
+#endif  // ROVIO_IMAGE_MASK_HPP_

--- a/include/rovio/ImgUpdate.hpp
+++ b/include/rovio/ImgUpdate.hpp
@@ -39,6 +39,7 @@
 #include "rovio/CoordinateTransform/PixelOutput.hpp"
 #include "rovio/ZeroVelocityUpdate.hpp"
 #include "rovio/MultilevelPatchAlignment.hpp"
+#include "rovio/ImageMask.hpp"
 
 namespace rovio {
 
@@ -183,6 +184,9 @@ ImgOutlierDetection<typename FILTERSTATE::mtState>,false>{
 
   // Multicamera pointer
   MultiCamera<mtState::nCam_>* mpMultiCamera_;
+
+  // Optional image mask for removing features in masked parts of an image.
+  ImageMask mask_;
 
   // Parameter
   M3D initCovFeature_;
@@ -987,6 +991,12 @@ ImgOutlierDetection<typename FILTERSTATE::mtState>,false>{
         for(int l=endLevel_;l<=startLevel_;l++){
           meas.aux().pyr_[camID].detectFastCorners(candidates_,l,fastDetectionThreshold_);
         }
+
+        bool apply_image_mask = true;
+        if (apply_image_mask) {
+          mask_.pruneFeatureVector(&candidates_);
+        }
+
         const double t2 = (double) cv::getTickCount();
         if(verbose_) std::cout << "== Detected " << candidates_.size() << " on levels " << endLevel_ << "-" << startLevel_ << " (" << (t2-t1)/cv::getTickFrequency()*1000 << " ms)" << std::endl;
         std::unordered_set<unsigned int> newSet = filterState.fsm_.addBestCandidates(candidates_,meas.aux().pyr_[camID],camID,filterState.t_,

--- a/include/rovio/ImgUpdate.hpp
+++ b/include/rovio/ImgUpdate.hpp
@@ -234,6 +234,7 @@ ImgOutlierDetection<typename FILTERSTATE::mtState>,false>{
   double discriminativeSamplingDistance_; /**<Sampling distance for checking discriminativity of patch (if <= 0.0 no check is performed).*/
   double discriminativeSamplingGain_; /**<Gain for threshold above which the samples must lie (if <= 1.0 the patchRejectionTh is used).*/
 
+  bool apply_image_mask_; /**< Whether to apply an image mask loaded from a path. */
 
   // Temporary
   mutable PixelOutputCT pixelOutputCT_;
@@ -992,8 +993,7 @@ ImgOutlierDetection<typename FILTERSTATE::mtState>,false>{
           meas.aux().pyr_[camID].detectFastCorners(candidates_,l,fastDetectionThreshold_);
         }
 
-        bool apply_image_mask = true;
-        if (apply_image_mask) {
+        if (apply_image_mask_) {
           mask_.pruneFeatureVector(&candidates_);
         }
 
@@ -1127,6 +1127,16 @@ ImgOutlierDetection<typename FILTERSTATE::mtState>,false>{
     cv::line(filterState.img_[camID],rollCenter-rollVector2,rollCenter-rollVector3,rollColor1, 2);
     cv::ellipse(filterState.img_[camID],rollCenter,cv::Size(10,10),0,0,180,rollColor1,2,8,0);
     cv::circle(filterState.img_[camID],rollCenter,2,rollColor1,-1,8,0);
+  }
+
+  void setImageMask(const std::string& image_path) {
+    if (mask_.loadImage(image_path)) {
+      apply_image_mask_ = true;
+    }
+  }
+
+  void clearImageMask() {
+    apply_image_mask_ = false;
   }
 };
 

--- a/include/rovio/RovioNode.hpp
+++ b/include/rovio/RovioNode.hpp
@@ -230,6 +230,13 @@ class RovioNode{
     }
     pubImuBias_ = nh_.advertise<sensor_msgs::Imu>("rovio/imu_biases", 1 );
 
+    // Set up image mask, if necessary.
+    std::string image_mask_path;
+    nh_private_.param("image_mask_path", image_mask_path, image_mask_path);
+    if (!image_mask_path.empty()) {
+      mpImgUpdate_->setImageMask(image_mask_path);
+    }
+
     // Handle coordinate frame naming
     map_frame_ = "/map";
     world_frame_ = "/world";

--- a/include/rovio/featureTracker.hpp
+++ b/include/rovio/featureTracker.hpp
@@ -37,6 +37,7 @@
 #include "rovio/MultiCamera.hpp"
 #include "rovio/FeatureManager.hpp"
 #include "rovio/MultilevelPatchAlignment.hpp"
+#include "rovio/ImageMask.hpp"
 
 namespace rovio{
 
@@ -68,6 +69,9 @@ class FeatureTrackerNode{
   static constexpr int detectionThreshold = 10; /**<See rovio::detectFastCorners().*/
   static constexpr bool drawNotFound_ = false;  /**<Draw MultilevelPatchFeature%s which were not found again.*/
   rovio::MultiCamera<nCam_> multiCamera_;
+
+  // Optional image mask for removing features in masked parts of an image.
+  ImageMask mask_;
 
   /** \brief Constructor
    */
@@ -234,6 +238,12 @@ class FeatureTrackerNode{
       for(int l=l1;l<=l2;l++){
         pyr_.detectFastCorners(candidates,l,detectionThreshold);
       }
+      bool apply_image_mask = true;
+      if (apply_image_mask) {
+        mask_.pruneFeatureVector(&candidates);
+      }
+
+
       const double t2 = (double) cv::getTickCount();
       ROS_INFO_STREAM(" == Detected " << candidates.size() << " on levels " << l1 << "-" << l2 << " (" << (t2-t1)/cv::getTickFrequency()*1000 << " ms)");
 //      pruneCandidates(fsm_,candidates,0);


### PR DESCRIPTION
In case you forget to mount your camera so that it doesn't look at your propellers or your frame. ;)
Simply prunes new feature detections before selecting best features to track based on whether their coordinates fall into the mask or not. 

Before:
![image](https://user-images.githubusercontent.com/5616392/53100778-a97cc080-3528-11e9-90da-4186a76768d2.png)

After:
![image](https://user-images.githubusercontent.com/5616392/53100810-bf8a8100-3528-11e9-98a5-a1bb1aa4e38e.png)


Mask applied: (black = filter, white = don't filter)
![gonzen_mask_big](https://user-images.githubusercontent.com/5616392/53100835-d204ba80-3528-11e9-9cff-3e70981fcb74.png)

Controlled by an optional ros param called "image_mask_path". If set to a path (here a png image), will automatically filter. Otherwise won't do anything.
