### PR TITLE
Update for opencv4 macros

### DIFF
--- a/include/rovio/ImgUpdate.hpp
+++ b/include/rovio/ImgUpdate.hpp
@@ -587,7 +587,11 @@ ImgOutlierDetection<typename FILTERSTATE::mtState>,false>{
     assert(filterState.t_ == meas.aux().imgTime_);
     for(int i=0;i<mtState::nCam_;i++){
       if(doFrameVisualisation_){
+      #if (CV_MAJOR_VERSION <= 3)
         cvtColor(meas.aux().pyr_[i].imgs_[0], filterState.img_[i], CV_GRAY2RGB);
+      #else
+        cvtColor(meas.aux().pyr_[i].imgs_[0], filterState.img_[i], cv::COLOR_GRAY2RGB);
+      #endif
       }
     }
     filterState.imgTime_ = filterState.t_;

--- a/include/rovio/featureTracker.hpp
+++ b/include/rovio/featureTracker.hpp
@@ -125,7 +125,11 @@ class FeatureTrackerNode{
     pyr_.computeFromImage(img_,true);
 
     // Drawing
+    #if (CV_MAJOR_VERSION <= 3)
     cvtColor(img_, draw_image_, CV_GRAY2RGB);
+    #else
+    cvtColor(img_, draw_image_, cv::COLOR_GRAY2RGB);
+    #endif
     const int numPatchesPlot = 10;
     draw_patches_ = cv::Mat::zeros(numPatchesPlot*(patchSize_*pow(2,nLevels_-1)+4),3*(patchSize_*pow(2,nLevels_-1)+4),CV_8UC1);
 


### PR DESCRIPTION
I wasn't able to build on ubuntu 20.04 with opencv4 because of the macro "CV_GRAY2RGB", which was replaced by "cv::COLOR_GRAY2RGB". This pull request fixes the problem, and should remain compatible with opencv3 or lower.
Please let me know if there is anything else you need me to do to be able to merge!